### PR TITLE
Fix `html-manifest#tr015` test

### DIFF
--- a/ldtest/models.py
+++ b/ldtest/models.py
@@ -1,13 +1,15 @@
 from dataclasses import dataclass
 from pathlib import Path
 
+from urlpath import URL
+
 
 @dataclass
 class TestCase:
     """JSON-LD Test Case."""
 
     test: str
-    input: Path
+    input: Path | URL
     result: Path | str | Exception   # noqa: WPS110
     req: str
     extract_all_scripts: bool = False
@@ -15,7 +17,11 @@ class TestCase:
     @property
     def raw_document(self) -> bytes:
         """Read the raw input document contents."""
-        return self.input.read_bytes()
+        path = self.input
+        if isinstance(path, URL):
+            path = Path(path.path)
+
+        return path.read_bytes()
 
     @property
     def raw_expected_document(self):

--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -20,10 +20,27 @@ tests = Namespace('https://w3c.github.io/json-ld-api/tests/vocab#')
 @pytest.mark.parametrize(
     'test_case',
     load_tests(tests.ToRDFTest),
-    ids=operator.attrgetter('test'),
+    ids=_.test,
 )
 def test_to_rdf(test_case: TestCase):
     raw_document = test_case.raw_document
+
+    if isinstance(test_case.result, str):
+        try:
+            expanded_document = yaml_ld.to_rdf(
+                raw_document,
+                extract_all_scripts=test_case.extract_all_scripts,
+            )
+        except YAMLLDError as error:
+            assert error.code == test_case.result
+            return
+
+        else:
+            pytest.fail(str(FailureToFail(
+                expected_error_code=test_case.result,
+                raw_document=test_case.raw_document,
+                expanded_document=expanded_document,
+            )))
 
     actual_dataset = yaml_ld.to_rdf(raw_document)
     raw_expected_quads = test_case.raw_expected_document
@@ -48,7 +65,7 @@ def test_expand(test_case: TestCase):
         else:
             pytest.fail(str(FailureToFail(
                 expected_error_code=test_case.result,
-                raw_document=test_case.input,
+                raw_document=test_case.raw_document,
                 expanded_document=expanded_document,
             )))
 

--- a/yaml_ld/to_rdf.py
+++ b/yaml_ld/to_rdf.py
@@ -4,19 +4,21 @@ from pyld import jsonld
 
 import yaml_ld
 from yaml_ld.annotations import Help
-from yaml_ld.models import Document, DocumentLoader
+from yaml_ld.models import Document, DocumentLoader, ExtractAllScripts
 from yaml_ld.rdf import Dataset
 
 
 def to_rdf(
     document: str | bytes | Document,
     base: Annotated[str | None, Help('The base IRI to use.')] = None,
+    extract_all_scripts: ExtractAllScripts = False,
     document_loader: DocumentLoader | None = None,
 ) -> Dataset:
     """Convert a YAML-LD document to RDF."""
     expanded_document = yaml_ld.expand(
         document=document,
         document_loader=document_loader,
+        extract_all_scripts=extract_all_scripts,
     )
 
     return jsonld.to_rdf(


### PR DESCRIPTION
# Why

Our `tr015` test is failing, in part because `yaml_ld.to_rdf` cannot accept `extract_all_scripts` but also because the testing framework wasn't operational enough.

# What

Fix the stuff!