### PR TITLE
73 to rdf

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,6 @@ YAML-LD is a YAML-based serialization for Linked Data, drawing inspiration from 
 - [:material-arrow-expand-all: `expand()`](/expand/)
 - :material-arrow-collapse: `compact()`
 - :compression: `flatten()`
-- :material-graph: `to_rdf()`
+- [:material-graph: `to_rdf()`](/to-rdf/)
 - :material-image-filter-frames: `frame()`
 </div>

--- a/docs/to-rdf.md
+++ b/docs/to-rdf.md
@@ -1,0 +1,26 @@
+---
+hide: [toc]
+---
+
+# :material-graph: `to_rdf()`
+
+!!! info "Specified by: [JSON-LD API]({{ yaml_ld.to_rdf.__annotations__.return.__metadata__|first }})"
+
+::: yaml_ld.to_rdf.to_rdf
+
+## Input & output
+
+
+|               | Type                                       | Default | Description |
+|-----------------------|---------------------------------------------|-------------|---|
+| `document`            | [SerializedDocument](/types/serialized-document/) \| [Document](/types/document/) |  | Document to expand.         |
+| `options`                | `ToRDFOptions | ToRDFOptionsDict`      | | Options |
+| :material-arrow-right-bottom-bold: **Returns** | [RDFDataset](/types/rdf-dataset/) | | RDF Dataset |
+
+## `ToRDFOptions` | `ToRDFOptionsDict`
+
+| `ToRDFOptions` | `ToRDFOptionsDict` | Type                                       | Default | Description |
+|-----|------------------|---------------------------------------------|-------------|---|
+| `context` | `context`            | [Document](/types/document/) \| `None` | `None` | A context to expand with. |
+| `extract_all_scripts` | `extractAllScripts` | `bool` | :x: `False` | Will we extract all scripts, or all documents in a YAML stream? |
+| `document_loader` | `documentLoader`     | `DocumentLoader`                           | `None` | Document Loader. |

--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -8,6 +8,7 @@ import funcy
 import pytest
 import rdflib
 from documented import Documented, DocumentedError
+from pydantic import ValidationError
 from pyld import jsonld
 from rdflib import Graph, Namespace
 from rdflib_pyld_compat.convert import (  # noqa: WPS450
@@ -115,7 +116,15 @@ def to_rdf():
                     expanded_document=rdf_document,
                 )))
 
-        actual_dataset = to_rdf(parse(test_case.raw_document))
+        try:
+            actual_dataset = to_rdf(parse(test_case.raw_document))
+        except ValidationError:
+            raise ValueError(
+                f'{test_case.raw_document!r} has type '
+                f'{type(test_case.raw_document)}, that is not what {to_rdf} '
+                'expects.',
+            )
+
         raw_expected_quads = test_case.raw_expected_document
 
         actual_triples = actual_dataset['@default']

--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+import funcy
 import pytest
 import rdflib
 from documented import Documented, DocumentedError
@@ -89,7 +90,11 @@ class NotIsomorphic(DocumentedError):
 
 @pytest.fixture()
 def to_rdf():
-    def _test(test_case: TestCase, parse: Callable, to_rdf: Callable) -> None:
+    def _test(
+        test_case: TestCase,
+        to_rdf: Callable,
+        parse: Callable = funcy.identity,
+    ) -> None:
         if isinstance(test_case.result, str):
             try:
                 rdf_document = to_rdf(
@@ -136,14 +141,13 @@ def test_to_rdf(test_case: TestCase, to_rdf):
     try:
         to_rdf(
             test_case=test_case,
-            parse=yaml_ld.parse,
             to_rdf=yaml_ld.to_rdf,
+            parse=yaml_ld.parse,
         )
     except NotIsomorphic:
         try:
             to_rdf(
                 test_case=test_case,
-                parse=json.loads,
                 to_rdf=jsonld.to_rdf,
             )
         except NotIsomorphic:

--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -120,7 +120,7 @@ def to_rdf():
 
         actual_triples = actual_dataset['@default']
         actual_graph: Graph = _rdflib_graph_from_pyld_dataset(actual_triples)
-        expected_graph = Graph().parse(data=raw_expected_quads)
+        expected_graph = Graph().parse(data=raw_expected_quads, format='nquads')
 
         if not actual_graph.isomorphic(expected_graph):
             raise NotIsomorphic(

--- a/yaml_ld/models.py
+++ b/yaml_ld/models.py
@@ -5,7 +5,7 @@ from typing import Any, Annotated, NewType
 from pydantic import BaseModel, Field, ConfigDict
 from urlpath import URL
 
-Document = dict[str, Any]   # type: ignore
+Document = dict[str, Any] | list[Any]  # type: ignore
 DocumentLoader = Any  # type: ignore   # FIXME: This is actually a callable.
 
 

--- a/yaml_ld/parse.py
+++ b/yaml_ld/parse.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, cast
 
 import funcy
 import yaml
@@ -93,12 +93,15 @@ def load_yaml_document(
 
 
 def parse(   # noqa: WPS238, WPS231, C901
-    raw_document: str | bytes | Path | URL,
+    raw_document: str | bytes | Path | URL | Document,
     extract_all_scripts: ExtractAllScripts = False,
     document_type: DocumentType | None = None,
 ) -> Document:
     """Parse a YAML-LD document."""
     fragment = None
+
+    if isinstance(raw_document, dict | list):
+        return cast(Document, raw_document)
 
     if isinstance(raw_document, URL):
         fragment = raw_document.fragment or None

--- a/yaml_ld/to_rdf.py
+++ b/yaml_ld/to_rdf.py
@@ -7,7 +7,7 @@ from urlpath import URL
 
 import yaml_ld
 from yaml_ld.annotations import Help
-from yaml_ld.expand import ExpandOptions
+from yaml_ld.expand import ExpandOptions, except_json_ld_errors
 from yaml_ld.models import (
     Document, DocumentLoader, ExtractAllScripts,
     SerializedDocument, BaseOptions,
@@ -25,9 +25,10 @@ def to_rdf(
     options: ToRDFOptions = ToRDFOptions(),
 ) -> Dataset:
     """Convert a YAML-LD document to RDF."""
-    expanded_document = yaml_ld.parse(
+    parsed_document = yaml_ld.parse(
         raw_document=document,
         extract_all_scripts=options.extract_all_scripts,
     )
 
-    return jsonld.to_rdf(expanded_document)
+    with except_json_ld_errors():
+        return jsonld.to_rdf(parsed_document)

--- a/yaml_ld/to_rdf.py
+++ b/yaml_ld/to_rdf.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Annotated
 
+from pydantic import validate_call
 from pyld import jsonld
 from urlpath import URL
 
@@ -9,26 +10,24 @@ from yaml_ld.annotations import Help
 from yaml_ld.expand import ExpandOptions
 from yaml_ld.models import (
     Document, DocumentLoader, ExtractAllScripts,
-    SerializedDocument,
+    SerializedDocument, BaseOptions,
 )
 from yaml_ld.rdf import Dataset
 
 
+class ToRDFOptions(BaseOptions):
+    ...
+
+
+@validate_call(config=dict(arbitrary_types_allowed=True))
 def to_rdf(
     document: SerializedDocument | Document,
-    base: Annotated[str | None, Help('The base IRI to use.')] = None,
-    extract_all_scripts: ExtractAllScripts = False,
-    document_loader: DocumentLoader | None = None,
+    options: ToRDFOptions = ToRDFOptions(),
 ) -> Dataset:
     """Convert a YAML-LD document to RDF."""
-    expanded_document = yaml_ld.expand(
-        document=document,
-        options=ExpandOptions(
-            document_loader=document_loader,
-            extract_all_scripts=extract_all_scripts,
-        ),
+    expanded_document = yaml_ld.parse(
+        raw_document=document,
+        extract_all_scripts=options.extract_all_scripts,
     )
 
-    return jsonld.to_rdf(
-        expanded_document,
-    )
+    return jsonld.to_rdf(expanded_document)

--- a/yaml_ld/to_rdf.py
+++ b/yaml_ld/to_rdf.py
@@ -6,7 +6,7 @@ from pyld import jsonld
 from urlpath import URL
 
 import yaml_ld
-from yaml_ld.annotations import Help
+from yaml_ld.annotations import Help, API
 from yaml_ld.expand import ExpandOptions, except_json_ld_errors
 from yaml_ld.models import (
     Document, DocumentLoader, ExtractAllScripts,
@@ -23,7 +23,7 @@ class ToRDFOptions(BaseOptions):
 def to_rdf(
     document: SerializedDocument | Document,
     options: ToRDFOptions = ToRDFOptions(),
-) -> Dataset:
+) -> Annotated[Dataset, API / '#dom-jsonldprocessor-tordf']:
     """Convert a YAML-LD document to RDF."""
     parsed_document = yaml_ld.parse(
         raw_document=document,


### PR DESCRIPTION
- `test_to_rdf` is now not silencing errors
- `except_json_ld_errors()` context manager
- `tr021` now good
- `te079` is fine
- Document `to_rdf() | closes #73
