### PR TITLE
remote manifest t0011 failing

### DIFF
--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -253,7 +253,7 @@ def test_expand(
             parse=yaml_ld.parse,
             expand=yaml_ld.expand,
         )
-    except (AssertionError, FailureToFail):
+    except (AssertionError, FailureToFail, YAMLLDError):
         if test_case.input.suffix in {'.yamlld', '.yaml'}:
             # The source document is in YAML-LD format, and we are failing on it
             raise

--- a/yaml_ld/document_loaders/local_file.py
+++ b/yaml_ld/document_loaders/local_file.py
@@ -35,7 +35,7 @@ class LocalFileDocumentLoader(DocumentLoader):
                     raise
 
                 except ScannerError as err:
-                    raise LoadingDocumentFailed() from err
+                    raise LoadingDocumentFailed(path=path) from err
 
                 except ComposerError as err:
                     from yaml_ld.errors import UndefinedAliasFound

--- a/yaml_ld/document_loaders/local_file.py
+++ b/yaml_ld/document_loaders/local_file.py
@@ -72,4 +72,4 @@ class LocalFileDocumentLoader(DocumentLoader):
                 'contentType': 'application/ld+yaml',
             }
 
-        raise LoadingDocumentFailed()
+        raise LoadingDocumentFailed(path=path)

--- a/yaml_ld/errors.py
+++ b/yaml_ld/errors.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from pathlib import Path
 
 from documented import DocumentedError
 
@@ -35,8 +36,13 @@ class DocumentIsScalar(YAMLLDError):
 
 @dataclass
 class LoadingDocumentFailed(YAMLLDError):
-    """Document is not a valid YAML."""
+    """
+    Document is not a valid YAML.
 
+    Path: {self.path}
+    """
+
+    path: Path
     code: str = 'loading document failed'
 
 


### PR DESCRIPTION
- Show which file has failed in the error message
- `remote-doc-manifest#t0011` is now 🟢
