### PR TITLE
flatten manifest t0035

### DIFF
--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -305,7 +305,7 @@ def test_compact(
         try:
             test_against_ld_library(
                 test_case=test_case,
-                parse=json.loads,
+                parse=_load_json_ld,
                 expand=jsonld.compact,
             )
         except AssertionError:
@@ -329,7 +329,7 @@ def test_flatten(
         try:
             test_against_ld_library(
                 test_case=test_case,
-                parse=json.loads,
+                parse=_load_json_ld,
                 expand=jsonld.flatten,
             )
         except AssertionError:
@@ -353,11 +353,10 @@ def test_frame(
         try:
             test_against_ld_library(
                 test_case=test_case,
-                parse=json.loads,
+                parse=_load_json_ld,
                 expand=jsonld.frame,
             )
         except AssertionError:
             pytest.skip('This test fails for pyld as well as for yaml-ld.')
         else:
             raise
-

--- a/yaml_ld/document_loaders/base.py
+++ b/yaml_ld/document_loaders/base.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from typing import TypedDict, Any
 
 PyLDResponse = TypedDict(
@@ -10,5 +11,6 @@ PyLDResponse = TypedDict(
 )
 
 
-class DocumentLoader:
-    ...
+class DocumentLoader(ABC):
+    def __call__(self, source: str, options: dict[str, Any]) -> PyLDResponse:
+        raise NotImplementedError()

--- a/yaml_ld/expand.py
+++ b/yaml_ld/expand.py
@@ -56,12 +56,13 @@ def expand(   # noqa: C901, WPS211
     options: ExpandOptions = ExpandOptions(),
 ) -> Document | list[Document]:
     """Expand a YAML-LD document."""
-    return jsonld.expand(
-        input_=str(document) if (
-            isinstance(document, (Path, URL))
-        ) else document,
-        options=options.model_dump(
-            by_alias=True,
-            exclude_defaults=True,
-        ),
-    )
+    with except_json_ld_errors():
+        return jsonld.expand(
+            input_=str(document) if (
+                isinstance(document, (Path, URL))
+            ) else document,
+            options=options.model_dump(
+                by_alias=True,
+                exclude_defaults=True,
+            ),
+        )

--- a/yaml_ld/expand.py
+++ b/yaml_ld/expand.py
@@ -56,13 +56,12 @@ def expand(   # noqa: C901, WPS211
     options: ExpandOptions = ExpandOptions(),
 ) -> Document | list[Document]:
     """Expand a YAML-LD document."""
-    with except_json_ld_errors():
-        return jsonld.expand(
-            input_=str(document) if (
-                isinstance(document, (Path, URL))
-            ) else document,
-            options=options.model_dump(
-                by_alias=True,
-                exclude_defaults=True,
-            ),
-        )
+    return jsonld.expand(
+        input_=str(document) if (
+            isinstance(document, (Path, URL))
+        ) else document,
+        options=options.model_dump(
+            by_alias=True,
+            exclude_defaults=True,
+        ),
+    )


### PR DESCRIPTION
- Show which file has failed in the error message
- `remote-doc-manifest#t0011` is now 🟢
- `basic-manifest#cr-well-formed-2-negative` is now 🟢
- Base `__call__` method for `DocumentLoader`
- Remove `except_json_ld_errors()`
