### PR TITLE
compact manifest tpr03

### DIFF
--- a/ldtest/models.py
+++ b/ldtest/models.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from urlpath import URL
 
+from yaml_ld.compact import CompactOptions
 from yaml_ld.expand import ExpandOptions
 from yaml_ld.models import Document
 from yaml_ld.to_rdf import ToRDFOptions
@@ -47,12 +48,15 @@ class TestCase:
 
         if self.test.startswith('toRdf'):
             options_class = ToRDFOptions
+        elif self.test.startswith('compact'):
+            options_class = CompactOptions
         else:
             options_class = ExpandOptions
 
         yield 'options', options_class(
             base=self.base,
             extract_all_scripts=self.extract_all_scripts,
+            expand_context=self.ctx,
         ).model_dump(
             by_alias=True,
             exclude_defaults=True,

--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -303,14 +303,14 @@ def test_compact(
             parse=yaml_ld.parse,
             expand=yaml_ld.compact,
         )
-    except AssertionError:
+    except (AssertionError, FailureToFail):
         try:
             test_against_ld_library(
                 test_case=test_case,
                 parse=_load_json_ld,
                 expand=jsonld.compact,
             )
-        except AssertionError:
+        except (AssertionError, FailureToFail):
             pytest.skip('This test fails for pyld as well as for yaml-ld.')
         else:
             raise

--- a/yaml_ld/compact.py
+++ b/yaml_ld/compact.py
@@ -33,9 +33,6 @@ def compact(  # noqa: WPS211
     options: CompactOptions = CompactOptions(),
 ) -> Document | list[Document]:
     """Compact a JSON-LD document."""
-    if isinstance(document, (str, bytes)):
-        document = parse(document)
-
     with except_json_ld_errors():
         return jsonld.compact(
             input_=document,


### PR DESCRIPTION
- `html-manifest#te017` is now 🟢
- `compact-manifest#tpr03` is now 🟢
