### PR TITLE
eradicate mypy errors

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,10 @@ jobs:
       - name: Install dependencies
         run: poetry install
 
+      - name: Lint
+        shell: bash
+        run: poetry run j lint
+
       - name: Test
         shell: bash
         run: poetry run j ci

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "add-trailing-comma"
-version = "2.5.1"
+version = "3.1.0"
 description = "Automatically add trailing commas to calls and literals"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "add_trailing_comma-2.5.1-py2.py3-none-any.whl", hash = "sha256:603b4b55f76f85237f4c848e93e56a4c84ebf8c9e329daf44ce3e8111d68557b"},
-    {file = "add_trailing_comma-2.5.1.tar.gz", hash = "sha256:f2a4afd41b96d6d34840455752c320c608942757ec6df3aa13b0b3c7effdd49e"},
+    {file = "add_trailing_comma-3.1.0-py2.py3-none-any.whl", hash = "sha256:160207e2ac414a841a71f4f5095f7350f87af460aab3dfe36cfa037992530e5c"},
+    {file = "add_trailing_comma-3.1.0.tar.gz", hash = "sha256:b255319d7ef6dca308b051ffd80fccf98c018879744c7c7e03083b2eee079c45"},
 ]
 
 [package.dependencies]
@@ -56,6 +56,20 @@ tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
 tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist[psutil]"]
 
 [[package]]
+name = "authlib"
+version = "1.3.1"
+description = "The ultimate Python library in building OAuth and OpenID Connect servers and clients."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Authlib-1.3.1-py2.py3-none-any.whl", hash = "sha256:d35800b973099bbadc49b42b256ecb80041ad56b7fe1216a362c7943c088f377"},
+    {file = "authlib-1.3.1.tar.gz", hash = "sha256:7ae843f03c06c5c0debd63c9db91f9fda64fa62a42a77419fa15fbb7e7a58917"},
+]
+
+[package.dependencies]
+cryptography = "*"
+
+[[package]]
 name = "babel"
 version = "2.15.0"
 description = "Internationalization utilities"
@@ -92,27 +106,6 @@ sarif = ["jschema-to-python (>=1.2.3)", "sarif-om (>=1.0.4)"]
 test = ["beautifulsoup4 (>=4.8.0)", "coverage (>=4.5.4)", "fixtures (>=3.0.0)", "flake8 (>=4.0.0)", "pylint (==1.9.4)", "stestr (>=2.5.0)", "testscenarios (>=0.5.0)", "testtools (>=2.3.0)"]
 toml = ["tomli (>=1.1.0)"]
 yaml = ["PyYAML"]
-
-[[package]]
-name = "beautifulsoup4"
-version = "4.12.3"
-description = "Screen-scraping library"
-optional = false
-python-versions = ">=3.6.0"
-files = [
-    {file = "beautifulsoup4-4.12.3-py3-none-any.whl", hash = "sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed"},
-    {file = "beautifulsoup4-4.12.3.tar.gz", hash = "sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051"},
-]
-
-[package.dependencies]
-soupsieve = ">1.2"
-
-[package.extras]
-cchardet = ["cchardet"]
-chardet = ["chardet"]
-charset-normalizer = ["charset-normalizer"]
-html5lib = ["html5lib"]
-lxml = ["lxml"]
 
 [[package]]
 name = "black"
@@ -192,6 +185,70 @@ files = [
     {file = "certifi-2024.6.2-py3-none-any.whl", hash = "sha256:ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56"},
     {file = "certifi-2024.6.2.tar.gz", hash = "sha256:3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516"},
 ]
+
+[[package]]
+name = "cffi"
+version = "1.16.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088"},
+    {file = "cffi-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ac0f5edd2360eea2f1daa9e26a41db02dd4b0451b48f7c318e217ee092a213e9"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e61e3e4fa664a8588aa25c883eab612a188c725755afff6289454d6362b9673"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a72e8961a86d19bdb45851d8f1f08b041ea37d2bd8d4fd19903bc3083d80c896"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b50bf3f55561dac5438f8e70bfcdfd74543fd60df5fa5f62d94e5867deca684"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7651c50c8c5ef7bdb41108b7b8c5a83013bfaa8a935590c5d74627c047a583c7"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4108df7fe9b707191e55f33efbcb2d81928e10cea45527879a4749cbe472614"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:32c68ef735dbe5857c810328cb2481e24722a59a2003018885514d4c09af9743"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:673739cb539f8cdaa07d92d02efa93c9ccf87e345b9a0b556e3ecc666718468d"},
+    {file = "cffi-1.16.0-cp310-cp310-win32.whl", hash = "sha256:9f90389693731ff1f659e55c7d1640e2ec43ff725cc61b04b2f9c6d8d017df6a"},
+    {file = "cffi-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:e6024675e67af929088fda399b2094574609396b1decb609c55fa58b028a32a1"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee07e47c12890ef248766a6e55bd38ebfb2bb8edd4142d56db91b21ea68b7627"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8a9d3ebe49f084ad71f9269834ceccbf398253c9fac910c4fd7053ff1386936"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e70f54f1796669ef691ca07d046cd81a29cb4deb1e5f942003f401c0c4a2695d"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5bf44d66cdf9e893637896c7faa22298baebcd18d1ddb6d2626a6e39793a1d56"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c6a164aa47843fb1b01e941d385aab7215563bb8816d80ff3a363a9f8448a8dc"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e09f3ff613345df5e8c3667da1d918f9149bd623cd9070c983c013792a9a62eb"},
+    {file = "cffi-1.16.0-cp311-cp311-win32.whl", hash = "sha256:2c56b361916f390cd758a57f2e16233eb4f64bcbeee88a4881ea90fca14dc6ab"},
+    {file = "cffi-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:fa3a0128b152627161ce47201262d3140edb5a5c3da88d73a1b790a959126956"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:68e7c44931cc171c54ccb702482e9fc723192e88d25a0e133edd7aff8fcd1f6e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd808f9c129ba2beda4cfc53bde801e5bcf9d6e0f22f095e45327c038bfe68e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88e2b3c14bdb32e440be531ade29d3c50a1a59cd4e51b1dd8b0865c54ea5d2e2"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcc8eb6d5902bb1cf6dc4f187ee3ea80a1eba0a89aba40a5cb20a5087d961357"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7be2d771cdba2942e13215c4e340bfd76398e9227ad10402a8767ab1865d2e6"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e715596e683d2ce000574bae5d07bd522c781a822866c20495e52520564f0969"},
+    {file = "cffi-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520"},
+    {file = "cffi-1.16.0-cp312-cp312-win32.whl", hash = "sha256:b2ca4e77f9f47c55c194982e10f058db063937845bb2b7a86c84a6cfe0aefa8b"},
+    {file = "cffi-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:68678abf380b42ce21a5f2abde8efee05c114c2fdb2e9eef2efdb0257fba1235"},
+    {file = "cffi-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a09582f178759ee8128d9270cd1344154fd473bb77d94ce0aeb2a93ebf0feaf0"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e760191dd42581e023a68b758769e2da259b5d52e3103c6060ddc02c9edb8d7b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80876338e19c951fdfed6198e70bc88f1c9758b94578d5a7c4c91a87af3cf31c"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a6a14b17d7e17fa0d207ac08642c8820f84f25ce17a442fd15e27ea18d67c59b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6602bc8dc6f3a9e02b6c22c4fc1e47aa50f8f8e6d3f78a5e16ac33ef5fefa324"},
+    {file = "cffi-1.16.0-cp38-cp38-win32.whl", hash = "sha256:131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a"},
+    {file = "cffi-1.16.0-cp38-cp38-win_amd64.whl", hash = "sha256:31d13b0f99e0836b7ff893d37af07366ebc90b678b6664c955b54561fc36ef36"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc9b18bf40cc75f66f40a7379f6a9513244fe33c0e8aa72e2d56b0196a7ef872"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b86851a328eedc692acf81fb05444bdf1891747c25af7529e39ddafaf68a4f3f"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c0f31130ebc2d37cdd8e44605fb5fa7ad59049298b3f745c74fa74c62fbfcfc4"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:748dcd1e3d3d7cd5443ef03ce8685043294ad6bd7c02a38d1bd367cfd968e000"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe"},
+    {file = "cffi-1.16.0-cp39-cp39-win32.whl", hash = "sha256:ed86a35631f7bfbb28e108dd96773b9d5a6ce4811cf6ea468bb6a359b256b1e4"},
+    {file = "cffi-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:3686dffb02459559c74dd3d81748269ffb0eb027c39a6fc99502de37d501faa8"},
+    {file = "cffi-1.16.0.tar.gz", hash = "sha256:bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0"},
+]
+
+[package.dependencies]
+pycparser = "*"
 
 [[package]]
 name = "charset-normalizer"
@@ -293,20 +350,6 @@ files = [
 ]
 
 [[package]]
-name = "classes"
-version = "0.4.1"
-description = "Smart, pythonic, ad-hoc, typed polymorphism for Python"
-optional = false
-python-versions = ">=3.7,<4.0"
-files = [
-    {file = "classes-0.4.1-py3-none-any.whl", hash = "sha256:934a19eb23d2fe0c0430af6eae6d81a4d4fcc53519cf737f69c3bba3994d54e9"},
-    {file = "classes-0.4.1.tar.gz", hash = "sha256:4de4fdd6c5c38607bbd8ad76703d7cc4dbe007cfa78e8ef1f62fc6ac55303e23"},
-]
-
-[package.dependencies]
-typing_extensions = ">=3.10,<5.0"
-
-[[package]]
 name = "click"
 version = "8.1.7"
 description = "Composable command line interface toolkit"
@@ -399,6 +442,60 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
+name = "cryptography"
+version = "42.0.8"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cryptography-42.0.8-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:81d8a521705787afe7a18d5bfb47ea9d9cc068206270aad0b96a725022e18d2e"},
+    {file = "cryptography-42.0.8-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:961e61cefdcb06e0c6d7e3a1b22ebe8b996eb2bf50614e89384be54c48c6b63d"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3ec3672626e1b9e55afd0df6d774ff0e953452886e06e0f1eb7eb0c832e8902"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e599b53fd95357d92304510fb7bda8523ed1f79ca98dce2f43c115950aa78801"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5226d5d21ab681f432a9c1cf8b658c0cb02533eece706b155e5fbd8a0cdd3949"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6b7c4f03ce01afd3b76cf69a5455caa9cfa3de8c8f493e0d3ab7d20611c8dae9"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:2346b911eb349ab547076f47f2e035fc8ff2c02380a7cbbf8d87114fa0f1c583"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:ad803773e9df0b92e0a817d22fd8a3675493f690b96130a5e24f1b8fabbea9c7"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2f66d9cd9147ee495a8374a45ca445819f8929a3efcd2e3df6428e46c3cbb10b"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d45b940883a03e19e944456a558b67a41160e367a719833c53de6911cabba2b7"},
+    {file = "cryptography-42.0.8-cp37-abi3-win32.whl", hash = "sha256:a0c5b2b0585b6af82d7e385f55a8bc568abff8923af147ee3c07bd8b42cda8b2"},
+    {file = "cryptography-42.0.8-cp37-abi3-win_amd64.whl", hash = "sha256:57080dee41209e556a9a4ce60d229244f7a66ef52750f813bfbe18959770cfba"},
+    {file = "cryptography-42.0.8-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:dea567d1b0e8bc5764b9443858b673b734100c2871dc93163f58c46a97a83d28"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4783183f7cb757b73b2ae9aed6599b96338eb957233c58ca8f49a49cc32fd5e"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0608251135d0e03111152e41f0cc2392d1e74e35703960d4190b2e0f4ca9c70"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dc0fdf6787f37b1c6b08e6dfc892d9d068b5bdb671198c72072828b80bd5fe4c"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9c0c1716c8447ee7dbf08d6db2e5c41c688544c61074b54fc4564196f55c25a7"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:fff12c88a672ab9c9c1cf7b0c80e3ad9e2ebd9d828d955c126be4fd3e5578c9e"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:cafb92b2bc622cd1aa6a1dce4b93307792633f4c5fe1f46c6b97cf67073ec961"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:31f721658a29331f895a5a54e7e82075554ccfb8b163a18719d342f5ffe5ecb1"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b297f90c5723d04bcc8265fc2a0f86d4ea2e0f7ab4b6994459548d3a6b992a14"},
+    {file = "cryptography-42.0.8-cp39-abi3-win32.whl", hash = "sha256:2f88d197e66c65be5e42cd72e5c18afbfae3f741742070e3019ac8f4ac57262c"},
+    {file = "cryptography-42.0.8-cp39-abi3-win_amd64.whl", hash = "sha256:fa76fbb7596cc5839320000cdd5d0955313696d9511debab7ee7278fc8b5c84a"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ba4f0a211697362e89ad822e667d8d340b4d8d55fae72cdd619389fb5912eefe"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:81884c4d096c272f00aeb1f11cf62ccd39763581645b0812e99a91505fa48e0c"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c9bb2ae11bfbab395bdd072985abde58ea9860ed84e59dbc0463a5d0159f5b71"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7016f837e15b0a1c119d27ecd89b3515f01f90a8615ed5e9427e30d9cdbfed3d"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5a94eccb2a81a309806027e1670a358b99b8fe8bfe9f8d329f27d72c094dde8c"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:dec9b018df185f08483f294cae6ccac29e7a6e0678996587363dc352dc65c842"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:343728aac38decfdeecf55ecab3264b015be68fc2816ca800db649607aeee648"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:013629ae70b40af70c9a7a5db40abe5d9054e6f4380e50ce769947b73bf3caad"},
+    {file = "cryptography-42.0.8.tar.gz", hash = "sha256:8d09d05439ce7baa8e9e95b07ec5b6c886f548deb7e0f69ef25f64b3bce842f2"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
+docstest = ["pyenchant (>=1.6.11)", "readme-renderer", "sphinxcontrib-spelling (>=4.0.1)"]
+nox = ["nox"]
+pep8test = ["check-sdist", "click", "mypy", "ruff"]
+sdist = ["build"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test-randomorder = ["pytest-randomly"]
+
+[[package]]
 name = "darglint"
 version = "1.8.1"
 description = "A utility for ensuring Google-style docstrings stay up to date with the source code."
@@ -407,17 +504,6 @@ python-versions = ">=3.6,<4.0"
 files = [
     {file = "darglint-1.8.1-py3-none-any.whl", hash = "sha256:5ae11c259c17b0701618a20c3da343a3eb98b3bc4b5a83d31cdd94f5ebdced8d"},
     {file = "darglint-1.8.1.tar.gz", hash = "sha256:080d5106df149b199822e7ee7deb9c012b49891538f14a11be681044f0bb20da"},
-]
-
-[[package]]
-name = "deepmerge"
-version = "0.1.1"
-description = "a toolset to deeply merge python dictionaries."
-optional = false
-python-versions = "*"
-files = [
-    {file = "deepmerge-0.1.1-py2.py3-none-any.whl", hash = "sha256:190e133a6657303db37f9bb302aa853d8d2b15a0e055d41b99a362598e79206a"},
-    {file = "deepmerge-0.1.1.tar.gz", hash = "sha256:fa1d44269786bcc12d30a7471b0b39478aa37a43703b134d7f12649792f92c1f"},
 ]
 
 [[package]]
@@ -472,13 +558,13 @@ files = [
 
 [[package]]
 name = "dparse"
-version = "0.6.3"
+version = "0.6.4b0"
 description = "A parser for Python dependency files"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "dparse-0.6.3-py3-none-any.whl", hash = "sha256:0d8fe18714056ca632d98b24fbfc4e9791d4e47065285ab486182288813a5318"},
-    {file = "dparse-0.6.3.tar.gz", hash = "sha256:27bb8b4bcaefec3997697ba3f6e06b2447200ba273c0b085c3d012a04571b528"},
+    {file = "dparse-0.6.4b0-py3-none-any.whl", hash = "sha256:592ff183348b8a5ea0a18442a7965e29445d3a26063654ec2c7e8ef42cd5753c"},
+    {file = "dparse-0.6.4b0.tar.gz", hash = "sha256:f8d49b41a527f3d16a269f854e6665245b325e50e41d2c213810cb984553e5c8"},
 ]
 
 [package.dependencies]
@@ -486,8 +572,10 @@ packaging = "*"
 tomli = {version = "*", markers = "python_version < \"3.11\""}
 
 [package.extras]
+all = ["dparse[conda]", "dparse[pipenv]", "dparse[poetry]"]
 conda = ["pyyaml"]
-pipenv = ["pipenv (<=2022.12.19)"]
+pipenv = ["pipenv"]
+poetry = ["poetry"]
 
 [[package]]
 name = "entrypoints"
@@ -901,48 +989,6 @@ files = [
 ]
 
 [[package]]
-name = "iolanta"
-version = "1.0.19"
-description = "Semantic Web browser"
-optional = false
-python-versions = ">=3.10,<4.0"
-files = [
-    {file = "iolanta-1.0.19-py3-none-any.whl", hash = "sha256:e256ddcfeabbda286e32adaeacadbfda5cf99dea78f9546424f9a57bb821a82f"},
-    {file = "iolanta-1.0.19.tar.gz", hash = "sha256:a9830f4403c051538c1199cd79cb44290882a4d201598988192c6ba156823e11"},
-]
-
-[package.dependencies]
-classes = ">=0.4.0,<0.5.0"
-deepmerge = ">=0.1.1,<0.2.0"
-documented = ">=0.1.1,<0.2.0"
-dominate = ">=2.6.0,<3.0.0"
-funcy = ">=2.0,<3.0"
-more-itertools = ">=9.0.0,<10.0.0"
-owlrl = ">=6.0.2,<7.0.0"
-PyLD = ">=2.0.3,<3.0.0"
-python-frontmatter = ">=0.5.0,<0.6.0"
-rdflib = ">=6.2.0,<7.0.0"
-requests = ">=2.25.1,<3.0.0"
-rich = ">=13.3.1,<14.0.0"
-typer = ">=0.9.0,<0.10.0"
-urlpath = ">=1.1.7,<2.0.0"
-
-[[package]]
-name = "iolanta-jinja2"
-version = "0.1.4"
-description = "Render Jinja2 templates from Iolanta graph"
-optional = false
-python-versions = ">=3.10,<4.0"
-files = [
-    {file = "iolanta_jinja2-0.1.4-py3-none-any.whl", hash = "sha256:9670c6810f8778a3bb7f05763d349302be052b63d575e4a931587f5fe413c3e7"},
-    {file = "iolanta_jinja2-0.1.4.tar.gz", hash = "sha256:a8db8289ee96e1a48aafe4ef8b75ee3ab8bd8ac193ae604a5d267d4473f29f27"},
-]
-
-[package.dependencies]
-iolanta = ">=1.0.12,<2.0.0"
-Jinja2 = ">=3.1.2,<4.0.0"
-
-[[package]]
 name = "isodate"
 version = "0.6.1"
 description = "An ISO 8601 date/time/duration parser and formatter"
@@ -993,32 +1039,31 @@ all = ["sh (>=2.0.4)"]
 
 [[package]]
 name = "jeeves-yeti-pyproject"
-version = "0.2.30"
+version = "0.2.31"
 description = "Opinionated Jeeves plugin for Python projects."
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "jeeves_yeti_pyproject-0.2.30-py3-none-any.whl", hash = "sha256:288ffe82383837f2816dcd6cd6b6d4d8968a483127ed21d2e8e3b7a5cc300860"},
-    {file = "jeeves_yeti_pyproject-0.2.30.tar.gz", hash = "sha256:75270072d74f2ade210f5061ad24130e84f1a355d7d64af65c97720aa1e09907"},
+    {file = "jeeves_yeti_pyproject-0.2.31-py3-none-any.whl", hash = "sha256:15b3173adba5053daee8ed27ed4540296aef04b3c650a6843fc6b94227f2e154"},
+    {file = "jeeves_yeti_pyproject-0.2.31.tar.gz", hash = "sha256:9d0c6df3d262132e2ac489e559ee06be08e6fbd551bf1c4113aec7ae5aa4b8bb"},
 ]
 
 [package.dependencies]
-add-trailing-comma = ">=2.4.0,<3.0.0"
-flakeheaven = ">=3.2.1,<4.0.0"
+add-trailing-comma = ">=2.4.0"
+flakeheaven = ">=3.2.1"
 jeeves-shell = {version = ">=2.3.0", extras = ["all"]}
-mkdocs = ">=1.4.2,<2.0.0"
-mkdocs-iolanta = ">=0.1.0,<0.2.0"
-mkdocs-macros-plugin = ">=0.7.0,<0.8.0"
-mkdocs-material = ">=9.0.3,<10.0.0"
+mkdocs = ">=1.4.2"
+mkdocs-macros-plugin = ">=0.7.0"
+mkdocs-material = ">=9.0.3"
 mypy = "<2.0"
-pytest = ">=7.4.2,<8.0.0"
-pytest-cov = ">=4.1.0,<5.0.0"
-pytest-randomly = ">=3.8,<4.0"
-rich = ">=13.3.1,<14.0.0"
-safety = ">=1.10,<2.0"
-tomlkit = ">=0.11.6,<0.12.0"
+pytest = ">=7.4.2"
+pytest-cov = ">=4.1.0"
+pytest-randomly = ">=3.8"
+rich = ">=13.3.1"
+safety = ">=1.10"
+tomlkit = ">=0.11.6"
 urllib3 = "<2.0.0"
-wemake-python-styleguide = ">=0.17.0,<0.18.0"
+wemake-python-styleguide = ">=0.17.0"
 
 [[package]]
 name = "jinja2"
@@ -1318,6 +1363,25 @@ files = [
 ]
 
 [[package]]
+name = "marshmallow"
+version = "3.21.3"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "marshmallow-3.21.3-py3-none-any.whl", hash = "sha256:86ce7fb914aa865001a4b2092c4c2872d13bc347f3d42673272cabfdbad386f1"},
+    {file = "marshmallow-3.21.3.tar.gz", hash = "sha256:4f57c5e050a54d66361e826f94fba213eb10b67b2fdb02c3e0343ce207ba1662"},
+]
+
+[package.dependencies]
+packaging = ">=17.0"
+
+[package.extras]
+dev = ["marshmallow[tests]", "pre-commit (>=3.5,<4.0)", "tox"]
+docs = ["alabaster (==0.7.16)", "autodocsumm (==0.2.12)", "sphinx (==7.3.7)", "sphinx-issues (==4.1.0)", "sphinx-version-warning (==1.1.2)"]
+tests = ["pytest", "pytz", "simplejson"]
+
+[[package]]
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
@@ -1446,31 +1510,14 @@ platformdirs = ">=2.2.0"
 pyyaml = ">=5.1"
 
 [[package]]
-name = "mkdocs-iolanta"
-version = "0.1.7"
-description = "MkDocs plugin to integrate with Iolanta semantic web framework."
-optional = false
-python-versions = ">=3.10,<4.0"
-files = [
-    {file = "mkdocs_iolanta-0.1.7-py3-none-any.whl", hash = "sha256:034febce1d7898182fed475ddc8e06f7b07bb24e1ada109a523deebaee23d1f3"},
-    {file = "mkdocs_iolanta-0.1.7.tar.gz", hash = "sha256:e94a44ae070d3a0102412a2d0c361d47f1109baa0cae4eea10f6712ebacef82f"},
-]
-
-[package.dependencies]
-iolanta = ">=1.0.14,<2.0.0"
-iolanta-jinja2 = ">=0.1.2,<0.2.0"
-mkdocs = ">=1.4.2,<2.0.0"
-mkdocs-macros-plugin = ">=0.7.0,<0.8.0"
-
-[[package]]
 name = "mkdocs-macros-plugin"
-version = "0.7.0"
+version = "1.0.5"
 description = "Unleash the power of MkDocs with macros and variables"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.8"
 files = [
-    {file = "mkdocs-macros-plugin-0.7.0.tar.gz", hash = "sha256:9e64e1cabcf6925359de29fe54f62d5847fb455c2528c440b87f8f1240650608"},
-    {file = "mkdocs_macros_plugin-0.7.0-py3-none-any.whl", hash = "sha256:96bdabeb98b96139544f0048ea2f5cb80c7befde6b21e94c6d4596c22774cbcf"},
+    {file = "mkdocs-macros-plugin-1.0.5.tar.gz", hash = "sha256:fe348d75f01c911f362b6d998c57b3d85b505876dde69db924f2c512c395c328"},
+    {file = "mkdocs_macros_plugin-1.0.5-py3-none-any.whl", hash = "sha256:f60e26f711f5a830ddf1e7980865bf5c0f1180db56109803cdd280073c1a050a"},
 ]
 
 [package.dependencies]
@@ -1485,13 +1532,13 @@ test = ["mkdocs-include-markdown-plugin", "mkdocs-macros-test", "mkdocs-material
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.27"
+version = "9.5.28"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs_material-9.5.27-py3-none-any.whl", hash = "sha256:af8cc263fafa98bb79e9e15a8c966204abf15164987569bd1175fd66a7705182"},
-    {file = "mkdocs_material-9.5.27.tar.gz", hash = "sha256:a7d4a35f6d4a62b0c43a0cfe7e987da0980c13587b5bc3c26e690ad494427ec0"},
+    {file = "mkdocs_material-9.5.28-py3-none-any.whl", hash = "sha256:ff48b11b2a9f705dd210409ec3b418ab443dd36d96915bcba45a41f10ea27bfd"},
+    {file = "mkdocs_material-9.5.28.tar.gz", hash = "sha256:9cba305283ad1600e3d0a67abe72d7a058b54793b47be39930911a588fe0336b"},
 ]
 
 [package.dependencies]
@@ -1565,17 +1612,6 @@ griffe = ">=0.47"
 mkdocstrings = ">=0.25"
 
 [[package]]
-name = "more-itertools"
-version = "9.1.0"
-description = "More routines for operating on iterables, beyond itertools"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "more-itertools-9.1.0.tar.gz", hash = "sha256:cabaa341ad0389ea83c17a94566a53ae4c9d07349861ecb14dc6d0345cf9ac5d"},
-    {file = "more_itertools-9.1.0-py3-none-any.whl", hash = "sha256:d2bc7f02446e86a68911e58ded76d6561eea00cddfb2a91e7019bbb586c799f3"},
-]
-
-[[package]]
 name = "mypy"
 version = "1.10.1"
 description = "Optional static typing for Python"
@@ -1647,20 +1683,6 @@ files = [
 [package.extras]
 fast = ["fastnumbers (>=2.0.0)"]
 icu = ["PyICU (>=1.0.0)"]
-
-[[package]]
-name = "owlrl"
-version = "6.0.2"
-description = "OWL-RL and RDFS based RDF Closure inferencing for Python"
-optional = false
-python-versions = "*"
-files = [
-    {file = "owlrl-6.0.2-py3-none-any.whl", hash = "sha256:57eca06b221edbbc682376c8d42e2ddffc99f61e82c0da02e26735592f08bacc"},
-    {file = "owlrl-6.0.2.tar.gz", hash = "sha256:904e3310ff4df15101475776693d2427d1f8244ee9a6a9f9e13c3c57fae90b74"},
-]
-
-[package.dependencies]
-rdflib = ">=6.0.2"
 
 [[package]]
 name = "packaging"
@@ -1759,6 +1781,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
     {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
+]
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
 
 [[package]]
@@ -1981,13 +2014,13 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "8.2.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-8.2.2-py3-none-any.whl", hash = "sha256:c434598117762e2bd304e526244f67bf66bbd7b5d6cf22138be51ff661980343"},
+    {file = "pytest-8.2.2.tar.gz", hash = "sha256:de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977"},
 ]
 
 [package.dependencies]
@@ -1995,21 +2028,21 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+pluggy = ">=1.5,<2.0"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
-version = "4.1.0"
+version = "5.0.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
-    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
+    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
+    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
 ]
 
 [package.dependencies]
@@ -2017,7 +2050,7 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-randomly"
@@ -2046,21 +2079,6 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
-
-[[package]]
-name = "python-frontmatter"
-version = "0.5.0"
-description = "Parse and manage posts with YAML (or other) frontmatter"
-optional = false
-python-versions = "*"
-files = [
-    {file = "python-frontmatter-0.5.0.tar.gz", hash = "sha256:a9c2e90fc38e9f0c68d8b82299040f331ca3b8525ac7fa5f6beffef52b26c426"},
-    {file = "python_frontmatter-0.5.0-py3-none-any.whl", hash = "sha256:a7dcdfdaf498d488dce98bfa9452f8b70f803a923760ceab1ebd99291d98d28a"},
-]
-
-[package.dependencies]
-PyYAML = "*"
-six = "*"
 
 [[package]]
 name = "pytz"
@@ -2148,13 +2166,13 @@ pyyaml = "*"
 
 [[package]]
 name = "rdflib"
-version = "6.3.2"
+version = "7.0.0"
 description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
 optional = false
-python-versions = ">=3.7,<4.0"
+python-versions = ">=3.8.1,<4.0.0"
 files = [
-    {file = "rdflib-6.3.2-py3-none-any.whl", hash = "sha256:36b4e74a32aa1e4fa7b8719876fb192f19ecd45ff932ea5ebbd2e417a0247e63"},
-    {file = "rdflib-6.3.2.tar.gz", hash = "sha256:72af591ff704f4caacea7ecc0c5a9056b8553e0489dd4f35a9bc52dbd41522e0"},
+    {file = "rdflib-7.0.0-py3-none-any.whl", hash = "sha256:0438920912a642c866a513de6fe8a0001bd86ef975057d6962c79ce4771687cd"},
+    {file = "rdflib-7.0.0.tar.gz", hash = "sha256:9995eb8569428059b8c1affd26b25eac510d64f5043d9ce8c84e0d0036e995ae"},
 ]
 
 [package.dependencies]
@@ -2324,22 +2342,132 @@ pygments = ">=2.13.0,<3.0.0"
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
-name = "safety"
-version = "1.10.3"
-description = "Checks installed dependencies for known vulnerabilities."
+name = "ruamel-yaml"
+version = "0.18.6"
+description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 files = [
-    {file = "safety-1.10.3-py2.py3-none-any.whl", hash = "sha256:5f802ad5df5614f9622d8d71fedec2757099705c2356f862847c58c6dfe13e84"},
-    {file = "safety-1.10.3.tar.gz", hash = "sha256:30e394d02a20ac49b7f65292d19d38fa927a8f9582cdfd3ad1adbbc66c641ad5"},
+    {file = "ruamel.yaml-0.18.6-py3-none-any.whl", hash = "sha256:57b53ba33def16c4f3d807c0ccbc00f8a6081827e81ba2491691b76882d0c636"},
+    {file = "ruamel.yaml-0.18.6.tar.gz", hash = "sha256:8b27e6a217e786c6fbe5634d8f3f11bc63e0f80f6a5890f28863d9c45aac311b"},
 ]
 
 [package.dependencies]
-Click = ">=6.0"
-dparse = ">=0.5.1"
-packaging = "*"
+"ruamel.yaml.clib" = {version = ">=0.2.7", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.13\""}
+
+[package.extras]
+docs = ["mercurial (>5.7)", "ryd"]
+jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.8"
+description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl", hash = "sha256:c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl", hash = "sha256:cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_24_aarch64.whl", hash = "sha256:1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win32.whl", hash = "sha256:53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win_amd64.whl", hash = "sha256:c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win32.whl", hash = "sha256:5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win_amd64.whl", hash = "sha256:1758ce7d8e1a29d23de54a16ae867abd370f01b5a69e1a3ba75223eaa3ca1a1b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win32.whl", hash = "sha256:75e1ed13e1f9de23c5607fe6bd1aeaae21e523b32d83bb33918245361e9cc51b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl", hash = "sha256:3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win32.whl", hash = "sha256:955eae71ac26c1ab35924203fda6220f84dce57d6d7884f189743e2abe3a9fbe"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl", hash = "sha256:56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win32.whl", hash = "sha256:84b554931e932c46f94ab306913ad7e11bba988104c5cff26d90d03f68258cd5"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win_amd64.whl", hash = "sha256:25ac8c08322002b06fa1d49d1646181f0b2c72f5cbc15a85e80b4c30a544bb15"},
+    {file = "ruamel.yaml.clib-0.2.8.tar.gz", hash = "sha256:beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512"},
+]
+
+[[package]]
+name = "safety"
+version = "3.2.3"
+description = "Checks installed dependencies for known vulnerabilities and licenses."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "safety-3.2.3-py3-none-any.whl", hash = "sha256:cda1e91749f610337a18b7f21f78267c127e44ebbbbcbbd419c83284279a5024"},
+    {file = "safety-3.2.3.tar.gz", hash = "sha256:414154934f1727daf8a6473493944fecb380540c3f00875dc1ae377382f7d83f"},
+]
+
+[package.dependencies]
+Authlib = ">=1.2.0"
+Click = ">=8.0.2"
+dparse = ">=0.6.4b0"
+jinja2 = ">=3.1.0"
+marshmallow = ">=3.15.0"
+packaging = ">=21.0"
+pydantic = ">=1.10.12"
 requests = "*"
-setuptools = "*"
+rich = "*"
+"ruamel.yaml" = ">=0.17.21"
+safety-schemas = ">=0.0.2"
+setuptools = ">=65.5.1"
+typer = "*"
+typing-extensions = ">=4.7.1"
+urllib3 = ">=1.26.5"
+
+[package.extras]
+github = ["pygithub (>=1.43.3)"]
+gitlab = ["python-gitlab (>=1.3.0)"]
+spdx = ["spdx-tools (>=0.8.2)"]
+
+[[package]]
+name = "safety-schemas"
+version = "0.0.2"
+description = "Schemas for Safety tools"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "safety_schemas-0.0.2-py3-none-any.whl", hash = "sha256:277c077ce6e53221874a87c29515ffdd2f3773a6db4d035a9f67cc98db3b8c7f"},
+    {file = "safety_schemas-0.0.2.tar.gz", hash = "sha256:7d1b040ec06480f05cff6b45ea7a93e09c8942df864fb0d01ddeb67c323cfa8c"},
+]
+
+[package.dependencies]
+dparse = ">=0.6.4b0"
+packaging = ">=21.0"
+pydantic = "*"
+ruamel-yaml = ">=0.17.21"
+typing-extensions = ">=4.7.1"
 
 [[package]]
 name = "setuptools"
@@ -2365,6 +2493,17 @@ python-versions = "<4.0,>=3.8.1"
 files = [
     {file = "sh-2.0.7-py3-none-any.whl", hash = "sha256:2f2f79a65abd00696cf2e9ad26508cf8abb6dba5745f40255f1c0ded2876926d"},
     {file = "sh-2.0.7.tar.gz", hash = "sha256:029d45198902bfb967391eccfd13a88d92f7cebd200411e93f99ebacc6afbb35"},
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+description = "Tool to Detect Surrounding Shell"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
 ]
 
 [[package]]
@@ -2398,17 +2537,6 @@ python-versions = "*"
 files = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
-]
-
-[[package]]
-name = "soupsieve"
-version = "2.5"
-description = "A modern CSS selector implementation for Beautiful Soup."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "soupsieve-2.5-py3-none-any.whl", hash = "sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7"},
-    {file = "soupsieve-2.5.tar.gz", hash = "sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690"},
 ]
 
 [[package]]
@@ -2490,35 +2618,31 @@ files = [
 
 [[package]]
 name = "tomlkit"
-version = "0.11.8"
+version = "0.12.5"
 description = "Style preserving TOML library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tomlkit-0.11.8-py3-none-any.whl", hash = "sha256:8c726c4c202bdb148667835f68d68780b9a003a9ec34167b6c673b38eff2a171"},
-    {file = "tomlkit-0.11.8.tar.gz", hash = "sha256:9330fc7faa1db67b541b28e62018c17d20be733177d290a13b24c62d1614e0c3"},
+    {file = "tomlkit-0.12.5-py3-none-any.whl", hash = "sha256:af914f5a9c59ed9d0762c7b64d3b5d5df007448eb9cd2edc8a46b1eafead172f"},
+    {file = "tomlkit-0.12.5.tar.gz", hash = "sha256:eef34fba39834d4d6b73c9ba7f3e4d1c417a4e56f89a7e96e090dd0d24b8fb3c"},
 ]
 
 [[package]]
 name = "typer"
-version = "0.9.4"
+version = "0.12.3"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "typer-0.9.4-py3-none-any.whl", hash = "sha256:aa6c4a4e2329d868b80ecbaf16f807f2b54e192209d7ac9dd42691d63f7a54eb"},
-    {file = "typer-0.9.4.tar.gz", hash = "sha256:f714c2d90afae3a7929fcd72a3abb08df305e1ff61719381384211c4070af57f"},
+    {file = "typer-0.12.3-py3-none-any.whl", hash = "sha256:070d7ca53f785acbccba8e7d28b08dcd88f79f1fbda035ade0aecec71ca5c914"},
+    {file = "typer-0.12.3.tar.gz", hash = "sha256:49e73131481d804288ef62598d97a1ceef3058905aa536a1134f90891ba35482"},
 ]
 
 [package.dependencies]
-click = ">=7.1.1,<9.0.0"
+click = ">=8.0.0"
+rich = ">=10.11.0"
+shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
-
-[package.extras]
-all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
-dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
-doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
-test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.971)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 
 [[package]]
 name = "types-pyyaml"
@@ -2669,4 +2793,4 @@ typing_extensions = ">=4.0,<5.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "5320c92eed816739137527826ca37c237f93fe332b4472fd1cdee101c7946834"
+content-hash = "f886e6905d662b5ffd17a3e962f63ff1be95ece643c86bc2dac41102a849b250"

--- a/poetry.lock
+++ b/poetry.lock
@@ -350,6 +350,20 @@ files = [
 ]
 
 [[package]]
+name = "classes"
+version = "0.4.1"
+description = "Smart, pythonic, ad-hoc, typed polymorphism for Python"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "classes-0.4.1-py3-none-any.whl", hash = "sha256:934a19eb23d2fe0c0430af6eae6d81a4d4fcc53519cf737f69c3bba3994d54e9"},
+    {file = "classes-0.4.1.tar.gz", hash = "sha256:4de4fdd6c5c38607bbd8ad76703d7cc4dbe007cfa78e8ef1f62fc6ac55303e23"},
+]
+
+[package.dependencies]
+typing_extensions = ">=3.10,<5.0"
+
+[[package]]
 name = "click"
 version = "8.1.7"
 description = "Composable command line interface toolkit"
@@ -504,6 +518,17 @@ python-versions = ">=3.6,<4.0"
 files = [
     {file = "darglint-1.8.1-py3-none-any.whl", hash = "sha256:5ae11c259c17b0701618a20c3da343a3eb98b3bc4b5a83d31cdd94f5ebdced8d"},
     {file = "darglint-1.8.1.tar.gz", hash = "sha256:080d5106df149b199822e7ee7deb9c012b49891538f14a11be681044f0bb20da"},
+]
+
+[[package]]
+name = "deepmerge"
+version = "0.1.1"
+description = "a toolset to deeply merge python dictionaries."
+optional = false
+python-versions = "*"
+files = [
+    {file = "deepmerge-0.1.1-py2.py3-none-any.whl", hash = "sha256:190e133a6657303db37f9bb302aa853d8d2b15a0e055d41b99a362598e79206a"},
+    {file = "deepmerge-0.1.1.tar.gz", hash = "sha256:fa1d44269786bcc12d30a7471b0b39478aa37a43703b134d7f12649792f92c1f"},
 ]
 
 [[package]]
@@ -987,6 +1012,33 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
+
+[[package]]
+name = "iolanta"
+version = "1.0.19"
+description = "Semantic Web browser"
+optional = false
+python-versions = ">=3.10,<4.0"
+files = [
+    {file = "iolanta-1.0.19-py3-none-any.whl", hash = "sha256:e256ddcfeabbda286e32adaeacadbfda5cf99dea78f9546424f9a57bb821a82f"},
+    {file = "iolanta-1.0.19.tar.gz", hash = "sha256:a9830f4403c051538c1199cd79cb44290882a4d201598988192c6ba156823e11"},
+]
+
+[package.dependencies]
+classes = ">=0.4.0,<0.5.0"
+deepmerge = ">=0.1.1,<0.2.0"
+documented = ">=0.1.1,<0.2.0"
+dominate = ">=2.6.0,<3.0.0"
+funcy = ">=2.0,<3.0"
+more-itertools = ">=9.0.0,<10.0.0"
+owlrl = ">=6.0.2,<7.0.0"
+PyLD = ">=2.0.3,<3.0.0"
+python-frontmatter = ">=0.5.0,<0.6.0"
+rdflib = ">=6.2.0,<7.0.0"
+requests = ">=2.25.1,<3.0.0"
+rich = ">=13.3.1,<14.0.0"
+typer = ">=0.9.0,<0.10.0"
+urlpath = ">=1.1.7,<2.0.0"
 
 [[package]]
 name = "isodate"
@@ -1612,6 +1664,17 @@ griffe = ">=0.47"
 mkdocstrings = ">=0.25"
 
 [[package]]
+name = "more-itertools"
+version = "9.1.0"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "more-itertools-9.1.0.tar.gz", hash = "sha256:cabaa341ad0389ea83c17a94566a53ae4c9d07349861ecb14dc6d0345cf9ac5d"},
+    {file = "more_itertools-9.1.0-py3-none-any.whl", hash = "sha256:d2bc7f02446e86a68911e58ded76d6561eea00cddfb2a91e7019bbb586c799f3"},
+]
+
+[[package]]
 name = "mypy"
 version = "1.10.1"
 description = "Optional static typing for Python"
@@ -1683,6 +1746,20 @@ files = [
 [package.extras]
 fast = ["fastnumbers (>=2.0.0)"]
 icu = ["PyICU (>=1.0.0)"]
+
+[[package]]
+name = "owlrl"
+version = "6.0.2"
+description = "OWL-RL and RDFS based RDF Closure inferencing for Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "owlrl-6.0.2-py3-none-any.whl", hash = "sha256:57eca06b221edbbc682376c8d42e2ddffc99f61e82c0da02e26735592f08bacc"},
+    {file = "owlrl-6.0.2.tar.gz", hash = "sha256:904e3310ff4df15101475776693d2427d1f8244ee9a6a9f9e13c3c57fae90b74"},
+]
+
+[package.dependencies]
+rdflib = ">=6.0.2"
 
 [[package]]
 name = "packaging"
@@ -2081,6 +2158,21 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-frontmatter"
+version = "0.5.0"
+description = "Parse and manage posts with YAML (or other) frontmatter"
+optional = false
+python-versions = "*"
+files = [
+    {file = "python-frontmatter-0.5.0.tar.gz", hash = "sha256:a9c2e90fc38e9f0c68d8b82299040f331ca3b8525ac7fa5f6beffef52b26c426"},
+    {file = "python_frontmatter-0.5.0-py3-none-any.whl", hash = "sha256:a7dcdfdaf498d488dce98bfa9452f8b70f803a923760ceab1ebd99291d98d28a"},
+]
+
+[package.dependencies]
+PyYAML = "*"
+six = "*"
+
+[[package]]
 name = "pytz"
 version = "2024.1"
 description = "World timezone definitions, modern and historical"
@@ -2166,13 +2258,13 @@ pyyaml = "*"
 
 [[package]]
 name = "rdflib"
-version = "7.0.0"
+version = "6.3.2"
 description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
 optional = false
-python-versions = ">=3.8.1,<4.0.0"
+python-versions = ">=3.7,<4.0"
 files = [
-    {file = "rdflib-7.0.0-py3-none-any.whl", hash = "sha256:0438920912a642c866a513de6fe8a0001bd86ef975057d6962c79ce4771687cd"},
-    {file = "rdflib-7.0.0.tar.gz", hash = "sha256:9995eb8569428059b8c1affd26b25eac510d64f5043d9ce8c84e0d0036e995ae"},
+    {file = "rdflib-6.3.2-py3-none-any.whl", hash = "sha256:36b4e74a32aa1e4fa7b8719876fb192f19ecd45ff932ea5ebbd2e417a0247e63"},
+    {file = "rdflib-6.3.2.tar.gz", hash = "sha256:72af591ff704f4caacea7ecc0c5a9056b8553e0489dd4f35a9bc52dbd41522e0"},
 ]
 
 [package.dependencies]
@@ -2496,17 +2588,6 @@ files = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
-description = "Tool to Detect Surrounding Shell"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
-    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
-]
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -2629,20 +2710,24 @@ files = [
 
 [[package]]
 name = "typer"
-version = "0.12.3"
+version = "0.9.4"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 files = [
-    {file = "typer-0.12.3-py3-none-any.whl", hash = "sha256:070d7ca53f785acbccba8e7d28b08dcd88f79f1fbda035ade0aecec71ca5c914"},
-    {file = "typer-0.12.3.tar.gz", hash = "sha256:49e73131481d804288ef62598d97a1ceef3058905aa536a1134f90891ba35482"},
+    {file = "typer-0.9.4-py3-none-any.whl", hash = "sha256:aa6c4a4e2329d868b80ecbaf16f807f2b54e192209d7ac9dd42691d63f7a54eb"},
+    {file = "typer-0.9.4.tar.gz", hash = "sha256:f714c2d90afae3a7929fcd72a3abb08df305e1ff61719381384211c4070af57f"},
 ]
 
 [package.dependencies]
-click = ">=8.0.0"
-rich = ">=10.11.0"
-shellingham = ">=1.3.0"
+click = ">=7.1.1,<9.0.0"
 typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
+doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
+test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.971)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 
 [[package]]
 name = "types-pyyaml"
@@ -2793,4 +2878,4 @@ typing_extensions = ">=4.0,<5.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "f886e6905d662b5ffd17a3e962f63ff1be95ece643c86bc2dac41102a849b250"
+content-hash = "b4422dd91c1cac28b472024d0332c2e96e6ce418a9e26e97407c4f70448a68c8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
-PyLD = "^2.0.4"
-pydantic = "^2.7.4"
-pyyaml = "^6.0.1"
-beautifulsoup4 = "^4.12.2"
+PyLD = ">=2.0.4"
+pydantic = ">=2.7.4"
+pyyaml = ">=6.0.1"
+urlpath = ">=1.2.0"
 
 [tool.poetry.group.dev.dependencies]
 jeeves-yeti-pyproject = { version = "^0.2.20", markers = "python_version >= '3.10'" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,10 @@ wemake-python-styleguide = [
     # Conflicts with class method docstrings.
     "-WPS462",
 ]
+
+[tool.flakeheaven.exceptions."**/*.py"]
+wemake-python-styleguide = [
+    # Found list comprehension with multiple `if`s
+    # I happen to like those ifs!
+    "-WPS307",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ mkdocs-blogging-plugin = "^2.2.11"
 mkdocstrings-python = "^1.10.5"
 black = "^24.4.2"
 dirty-equals = "^0.7.1.post0"
+iolanta = "^1.0.19"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,11 @@ dirty-equals = "^0.7.1.post0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+
+[tool.flakeheaven.exceptions."yaml_ld/*.py"]
+wemake-python-styleguide = [
+    # Wrong multiline string usage
+    # Conflicts with class method docstrings.
+    "-WPS462",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from yaml_ld.errors import YAMLLDError
 def verify_from_rdf():
     def _test(
         test_case: TestCase,
-        from_rdf: Callable,
+        from_rdf,
     ) -> None:
         if isinstance(test_case.result, str):
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,8 @@ from yaml_ld.errors import YAMLLDError
 
 
 @pytest.fixture()
-def verify_from_rdf():
-    def _test(
+def verify_from_rdf():   # noqa: C901, WPS231
+    def _test(   # noqa: WPS430
         test_case: TestCase,
         from_rdf,
     ) -> None:
@@ -25,13 +25,12 @@ def verify_from_rdf():
                 assert error.code == test_case.result
                 return
 
-            else:
-                raise FailureToFail(
-                    test_case=test_case,
-                    expected_error_code=test_case.result,
-                    raw_document=test_case.raw_document,
-                    expanded_document=rdf_document,
-                )
+            raise FailureToFail(
+                test_case=test_case,
+                expected_error_code=test_case.result,
+                raw_document=test_case.raw_document,
+                expanded_document=rdf_document,
+            )
 
         try:
             actual_ld = from_rdf(

--- a/tests/errors.py
+++ b/tests/errors.py
@@ -8,7 +8,7 @@ from yaml_ld.models import JsonLdRecord
 
 
 @dataclass
-class FailureToFail(DocumentedError):
+class FailureToFail(DocumentedError):   # type: ignore
     """
     YAMLLDError not raised.
 

--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -40,14 +40,11 @@ def _get_id(test_case: TestCase) -> str | None:
 
     See https://github.com/pytest-dev/pytest/issues/7686
     """
-    if not isinstance(test_case, TestCase):
-        return None
-
     return test_case.test
 
 
 @dataclass
-class NotIsomorphic(DocumentedError):
+class NotIsomorphic(DocumentedError):   # type: ignore
     """
     Actual RDF graph does not match expected graph.
 
@@ -96,7 +93,7 @@ class NotIsomorphic(DocumentedError):
 def to_rdf():
     def _test(
         test_case: TestCase,
-        to_rdf: Callable,
+        to_rdf,
     ) -> None:
         if isinstance(test_case.result, str):
             try:
@@ -168,15 +165,15 @@ def test_to_rdf(test_case: TestCase, to_rdf):
 
 
 @dataclass
-class CallableUnexpectedlyFailed(DocumentedError):
+class CallableUnexpectedlyFailed(DocumentedError):   # type: ignore
     """
     `{self.callable_path}()` unexpectedly failed with an exception.
 
     Args: {self.params}
     """
 
-    callable: Callable
-    params: Any
+    callable: Any    # type: ignore
+    params: Any      # type: ignore
 
     @property
     def callable_path(self):
@@ -212,7 +209,7 @@ def print_diff(actual, expected) -> None:
 
 @pytest.fixture()
 def test_against_ld_library():
-    def _test(test_case: TestCase, expand: Callable) -> None:
+    def _test(test_case: TestCase, expand) -> None:
         match test_case.result:
             case str() as error_code:
                 try:

--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -106,25 +106,17 @@ def to_rdf():  # noqa: C901, WPS231
                 assert error.code == test_case.result
                 return
 
-            else:
-                raise FailureToFail(
-                    test_case=test_case,
-                    expected_error_code=test_case.result,
-                    raw_document=test_case.raw_document,
-                    expanded_document=rdf_document,
-                )
+            raise FailureToFail(
+                test_case=test_case,
+                expected_error_code=test_case.result,
+                raw_document=test_case.raw_document,
+                expanded_document=rdf_document,
+            )
 
-        try:
-            actual_dataset = to_rdf_callable(
-                test_case.input,
-                **test_case.kwargs,
-            )
-        except ValidationError:
-            raise ValueError(
-                f'{test_case.raw_document!r} has type '
-                f'{type(test_case.raw_document)}, that is not what '
-                f'{to_rdf_callable} expects.',
-            )
+        actual_dataset = to_rdf_callable(
+            test_case.input,
+            **test_case.kwargs,
+        )
 
         raw_expected_quads = test_case.raw_expected_document
 
@@ -151,13 +143,13 @@ def test_to_rdf(test_case: TestCase, to_rdf):
     try:
         to_rdf(
             test_case=test_case,
-            to_rdf=yaml_ld.to_rdf,
+            to_rdf_callable=yaml_ld.to_rdf,
         )
     except (NotIsomorphic, FailureToFail):
-        try:
+        try:   # noqa: WPS505
             to_rdf(
                 test_case=test_case,
-                to_rdf=jsonld.to_rdf,
+                to_rdf_callable=jsonld.to_rdf,
             )
         except (NotIsomorphic, FailureToFail):
             pytest.skip('This test fails for pyld as well as for yaml-ld.')

--- a/yaml_ld/compact.py
+++ b/yaml_ld/compact.py
@@ -12,7 +12,7 @@ from yaml_ld.models import (
 )
 
 
-class CompactOptions(BaseOptions, ExtractAllScriptsOptions):
+class CompactOptions(BaseOptions, ExtractAllScriptsOptions):   # type: ignore
     """Options to compact a YAML-LD document."""
 
     compact_arrays: bool = True

--- a/yaml_ld/document_loaders/base.py
+++ b/yaml_ld/document_loaders/base.py
@@ -18,7 +18,7 @@ DocumentLoaderOptions = TypedDict(
     'DocumentLoaderOptions',
     {
         'extractAllScripts': bool,
-    }
+    },
 )
 
 

--- a/yaml_ld/document_loaders/base.py
+++ b/yaml_ld/document_loaders/base.py
@@ -10,7 +10,7 @@ PyLDResponse = TypedDict(
         'contentType': str,
         'contextUrl': str | None,
         'documentUrl': str,
-        'document': JsonLdRecord,
+        'document': JsonLdRecord | list[JsonLdRecord],
     },
 )
 

--- a/yaml_ld/document_loaders/base.py
+++ b/yaml_ld/document_loaders/base.py
@@ -8,7 +8,7 @@ from yaml_ld.models import JsonLdRecord
 PyLDResponse = TypedDict(
     'PyLDResponse', {
         'contentType': str,
-        'contextUrl': str | None,
+        'contextUrl': str | None,   # noqa: WPS465
         'documentUrl': str,
         'document': JsonLdRecord | list[JsonLdRecord],
     },

--- a/yaml_ld/document_loaders/choice_by_scheme.py
+++ b/yaml_ld/document_loaders/choice_by_scheme.py
@@ -14,7 +14,7 @@ from yaml_ld.document_loaders.base import (
 
 
 @dataclass
-class ProtocolNotFound(DocumentedError):
+class ProtocolNotFound(DocumentedError):  # type: ignore
     """
     Cannot choose the loader by URL protocol.
 

--- a/yaml_ld/document_loaders/choice_by_scheme.py
+++ b/yaml_ld/document_loaders/choice_by_scheme.py
@@ -8,8 +8,9 @@ from pydantic import validate_call
 from urlpath import URL
 
 from yaml_ld.document_loaders.base import (
-    DocumentLoader, PyLDResponse,
+    DocumentLoader,
     DocumentLoaderOptions,
+    PyLDResponse,
 )
 
 

--- a/yaml_ld/document_loaders/http.py
+++ b/yaml_ld/document_loaders/http.py
@@ -9,13 +9,18 @@ from yaml_ld.document_loaders.base import (
     DocumentLoaderOptions,
     PyLDResponse,
 )
+from yaml_ld.errors import LoadingDocumentFailed
 
 
 class HTTPDocumentLoader(DocumentLoader):
+    """Load documents from HTTP sources."""
 
-    def __call__(self, source: str | Path, options: DocumentLoaderOptions) -> PyLDResponse:
-        from yaml_ld.errors import LoadingDocumentFailed
-
+    def __call__(
+        self,
+        source: str | Path,
+        options: DocumentLoaderOptions,
+    ) -> PyLDResponse:
+        """Load documents from HTTP sources."""
         url = URL(source)
 
         content = url.get(stream=True).raw

--- a/yaml_ld/document_loaders/http.py
+++ b/yaml_ld/document_loaders/http.py
@@ -23,8 +23,8 @@ class HTTPDocumentLoader(DocumentLoader):
         """Load documents from HTTP sources."""
         url = URL(source)
 
-        content = url.get(stream=True).raw
-        content.decode_content = True
+        raw_content = url.get(stream=True).raw
+        raw_content.decode_content = True
 
         content_type = content_types.by_extension(url.suffix)
         if content_type is None:
@@ -34,7 +34,7 @@ class HTTPDocumentLoader(DocumentLoader):
         if parser is None:
             raise LoadingDocumentFailed(path=source)
 
-        yaml_document = parser(content, str(source), options)
+        yaml_document = parser(raw_content, str(source), options)
 
         return {
             'document': yaml_document,

--- a/yaml_ld/document_loaders/http.py
+++ b/yaml_ld/document_loaders/http.py
@@ -5,8 +5,9 @@ from urlpath import URL
 
 from yaml_ld.document_loaders import content_types
 from yaml_ld.document_loaders.base import (
-    DocumentLoader, PyLDResponse,
+    DocumentLoader,
     DocumentLoaderOptions,
+    PyLDResponse,
 )
 
 

--- a/yaml_ld/document_loaders/local_file.py
+++ b/yaml_ld/document_loaders/local_file.py
@@ -12,12 +12,14 @@ from yaml_ld.errors import LoadingDocumentFailed, NotFound
 
 
 class LocalFileDocumentLoader(DocumentLoader):
+    """Load documents from a local file system."""
 
     def __call__(
         self,
         source: str | Path,
         options: DocumentLoaderOptions,
     ) -> PyLDResponse:
+        """Load documents from a local file system."""
         path = Path(URL(source).path)
 
         content_type = content_types.by_extension(path.suffix)

--- a/yaml_ld/document_loaders/local_file.py
+++ b/yaml_ld/document_loaders/local_file.py
@@ -11,8 +11,9 @@ from yaml.scanner import ScannerError
 
 from yaml_ld.document_loaders import content_types
 from yaml_ld.document_loaders.base import (
-    DocumentLoader, PyLDResponse,
+    DocumentLoader,
     DocumentLoaderOptions,
+    PyLDResponse,
 )
 from yaml_ld.document_parsers.html_parser import HTMLDocumentParser
 from yaml_ld.document_parsers.yaml_parser import YAMLDocumentParser

--- a/yaml_ld/document_loaders/local_file.py
+++ b/yaml_ld/document_loaders/local_file.py
@@ -8,7 +8,7 @@ from yaml_ld.document_loaders.base import (
     DocumentLoaderOptions,
     PyLDResponse,
 )
-from yaml_ld.errors import NotFound, LoadingDocumentFailed
+from yaml_ld.errors import LoadingDocumentFailed, NotFound
 
 
 class LocalFileDocumentLoader(DocumentLoader):

--- a/yaml_ld/document_loaders/local_file.py
+++ b/yaml_ld/document_loaders/local_file.py
@@ -8,7 +8,7 @@ from yaml_ld.document_loaders.base import (
     DocumentLoaderOptions,
     PyLDResponse,
 )
-from yaml_ld.errors import NotFound
+from yaml_ld.errors import NotFound, LoadingDocumentFailed
 
 
 class LocalFileDocumentLoader(DocumentLoader):
@@ -18,8 +18,6 @@ class LocalFileDocumentLoader(DocumentLoader):
         source: str | Path,
         options: DocumentLoaderOptions,
     ) -> PyLDResponse:
-        from yaml_ld.errors import LoadingDocumentFailed
-
         path = Path(URL(source).path)
 
         content_type = content_types.by_extension(path.suffix)

--- a/yaml_ld/document_loaders/local_file.py
+++ b/yaml_ld/document_loaders/local_file.py
@@ -23,7 +23,11 @@ from yaml_ld.loader import YAMLLDLoader
 
 class LocalFileDocumentLoader(DocumentLoader):
 
-    def __call__(self, source: str | Path, options: DocumentLoaderOptions) -> PyLDResponse:
+    def __call__(
+        self,
+        source: str | Path,
+        options: DocumentLoaderOptions,
+    ) -> PyLDResponse:
         from yaml_ld.errors import DocumentIsScalar, LoadingDocumentFailed
 
         path = Path(URL(source).path)

--- a/yaml_ld/document_loaders/local_file.py
+++ b/yaml_ld/document_loaders/local_file.py
@@ -1,13 +1,6 @@
 from pathlib import Path
-from typing import Any
 
-import more_itertools
-import yaml
 from urlpath import URL
-from yaml.composer import ComposerError
-from yaml.constructor import ConstructorError
-from yaml.parser import ParserError
-from yaml.scanner import ScannerError
 
 from yaml_ld.document_loaders import content_types
 from yaml_ld.document_loaders.base import (
@@ -15,11 +8,7 @@ from yaml_ld.document_loaders.base import (
     DocumentLoaderOptions,
     PyLDResponse,
 )
-from yaml_ld.document_parsers.html_parser import HTMLDocumentParser
-from yaml_ld.document_parsers.yaml_parser import YAMLDocumentParser
 from yaml_ld.errors import NotFound
-from yaml_ld.load_html import load_html
-from yaml_ld.loader import YAMLLDLoader
 
 
 class LocalFileDocumentLoader(DocumentLoader):
@@ -29,7 +18,7 @@ class LocalFileDocumentLoader(DocumentLoader):
         source: str | Path,
         options: DocumentLoaderOptions,
     ) -> PyLDResponse:
-        from yaml_ld.errors import DocumentIsScalar, LoadingDocumentFailed
+        from yaml_ld.errors import LoadingDocumentFailed
 
         path = Path(URL(source).path)
 

--- a/yaml_ld/document_loaders/mock.py
+++ b/yaml_ld/document_loaders/mock.py
@@ -3,8 +3,9 @@ from pathlib import Path
 from typing import Any
 
 from yaml_ld.document_loaders.base import (
-    DocumentLoader, PyLDResponse,
+    DocumentLoader,
     DocumentLoaderOptions,
+    PyLDResponse,
 )
 
 

--- a/yaml_ld/document_loaders/mock.py
+++ b/yaml_ld/document_loaders/mock.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 from yaml_ld.document_loaders.base import (
     DocumentLoader,

--- a/yaml_ld/document_parsers/base.py
+++ b/yaml_ld/document_parsers/base.py
@@ -11,7 +11,7 @@ class BaseDocumentParser:
     @abstractmethod
     def __call__(
         self,
-        data: io.TextIOBase,
+        data_stream: io.TextIOBase,
         source: str,
         options: DocumentLoaderOptions,
     ) -> JsonLdRecord | list[JsonLdRecord]:

--- a/yaml_ld/document_parsers/base.py
+++ b/yaml_ld/document_parsers/base.py
@@ -1,5 +1,6 @@
 import io
 from abc import abstractmethod
+
 from typing_extensions import TypedDict
 
 from yaml_ld.document_loaders.base import DocumentLoaderOptions

--- a/yaml_ld/document_parsers/base.py
+++ b/yaml_ld/document_parsers/base.py
@@ -8,5 +8,10 @@ from yaml_ld.models import JsonLdRecord
 
 class BaseDocumentParser:
     @abstractmethod
-    def __call__(self, data: io.TextIOBase, source: str, options: DocumentLoaderOptions) -> JsonLdRecord:
+    def __call__(
+        self,
+        data: io.TextIOBase,
+        source: str,
+        options: DocumentLoaderOptions,
+    ) -> JsonLdRecord | list[JsonLdRecord]:
         raise NotImplementedError()

--- a/yaml_ld/document_parsers/base.py
+++ b/yaml_ld/document_parsers/base.py
@@ -1,8 +1,6 @@
 import io
 from abc import abstractmethod
 
-from typing_extensions import TypedDict
-
 from yaml_ld.document_loaders.base import DocumentLoaderOptions
 from yaml_ld.models import JsonLdRecord
 
@@ -15,4 +13,5 @@ class BaseDocumentParser:
         source: str,
         options: DocumentLoaderOptions,
     ) -> JsonLdRecord | list[JsonLdRecord]:
+        """Parse raw data into Linked Data."""
         raise NotImplementedError()

--- a/yaml_ld/document_parsers/base.py
+++ b/yaml_ld/document_parsers/base.py
@@ -6,6 +6,8 @@ from yaml_ld.models import JsonLdRecord
 
 
 class BaseDocumentParser:
+    """Parse documents of various types into LD."""
+
     @abstractmethod
     def __call__(
         self,

--- a/yaml_ld/document_parsers/html_parser.py
+++ b/yaml_ld/document_parsers/html_parser.py
@@ -28,7 +28,7 @@ class HTMLDocumentParser(BaseDocumentParser):
         data: io.TextIOBase,
         source: str,
         options: DocumentLoaderOptions,
-    ) -> JsonLdRecord:
+    ) -> JsonLdRecord | list[JsonLdRecord]:
         loaded_html = load_html(
             input=data.read(),
             url=source,

--- a/yaml_ld/document_parsers/html_parser.py
+++ b/yaml_ld/document_parsers/html_parser.py
@@ -25,12 +25,12 @@ class HTMLDocumentParser(BaseDocumentParser):
 
     def __call__(
         self,
-        data: io.TextIOBase,
+        data_stream: io.TextIOBase,
         source: str,
         options: DocumentLoaderOptions,
     ) -> JsonLdRecord | list[JsonLdRecord]:
         loaded_html = load_html(
-            input=data.read(),
+            input=data_stream.read(),
             url=source,
             profile=None,
             options=options,

--- a/yaml_ld/document_parsers/html_parser.py
+++ b/yaml_ld/document_parsers/html_parser.py
@@ -29,6 +29,7 @@ class HTMLDocumentParser(BaseDocumentParser):
         source: str,
         options: DocumentLoaderOptions,
     ) -> JsonLdRecord | list[JsonLdRecord]:
+        """Parse HTML with LD in <script> tags."""
         loaded_html = load_html(
             input=data_stream.read(),
             url=source,

--- a/yaml_ld/document_parsers/yaml_parser.py
+++ b/yaml_ld/document_parsers/yaml_parser.py
@@ -15,7 +15,8 @@ from yaml_ld.document_parsers.base import (
 from yaml_ld.errors import (
     DocumentIsScalar,
     InvalidEncoding,
-    LoadingDocumentFailed, MappingKeyError,
+    LoadingDocumentFailed,
+    MappingKeyError,
 )
 from yaml_ld.loader import YAMLLDLoader
 from yaml_ld.models import JsonLdRecord

--- a/yaml_ld/document_parsers/yaml_parser.py
+++ b/yaml_ld/document_parsers/yaml_parser.py
@@ -1,7 +1,5 @@
 import io
-from typing import Any
 
-import more_itertools
 import yaml
 from yaml.composer import ComposerError
 from yaml.constructor import ConstructorError
@@ -23,6 +21,15 @@ from yaml_ld.models import JsonLdRecord
 
 
 class YAMLDocumentParser(BaseDocumentParser):
+    def _yaml_document_from_stream(self, stream, extract_all_scripts: bool):
+        if extract_all_scripts:
+            return list(stream)
+
+        try:
+            return next(stream)
+        except StopIteration as stop_iteration:
+            raise LoadingDocumentFailed(path='') from stop_iteration
+
     def __call__(
         self,
         data_stream: io.TextIOBase,
@@ -30,27 +37,19 @@ class YAMLDocumentParser(BaseDocumentParser):
         options: DocumentLoaderOptions,
     ) -> JsonLdRecord | list[JsonLdRecord]:
         """Parse YAML document stream into LD."""
+        yaml_documents_stream = yaml.load_all(  # noqa: S506
+            stream=data_stream,
+            Loader=YAMLLDLoader,
+        )
+
         try:
-            yaml_documents_stream = yaml.load_all(  # noqa: S506
-                stream=data_stream,
-                Loader=YAMLLDLoader,
+            yaml_document = self._yaml_document_from_stream(
+                stream=yaml_documents_stream,
+                extract_all_scripts=options.get('extractAllScripts', False),
             )
+        except UnicodeDecodeError as unicode_decode_error:
+            raise InvalidEncoding() from unicode_decode_error
 
-            try:
-                if options.get('extractAllScripts'):
-                    yaml_document = list(yaml_documents_stream)
-                else:
-                    try:
-                        yaml_document = more_itertools.first(yaml_documents_stream)
-                    except ValueError as empty_iterable:
-                        if 'first() was called on an empty iterable' in str(empty_iterable):
-                            raise LoadingDocumentFailed(
-                                path=source,
-                            ) from empty_iterable
-
-                        raise
-            except UnicodeDecodeError as unicode_decode_error:
-                raise InvalidEncoding() from unicode_decode_error
         except ConstructorError as err:
             if err.problem == 'found unhashable key':
                 raise MappingKeyError() from err

--- a/yaml_ld/document_parsers/yaml_parser.py
+++ b/yaml_ld/document_parsers/yaml_parser.py
@@ -24,14 +24,14 @@ from yaml_ld.models import JsonLdRecord
 class YAMLDocumentParser(BaseDocumentParser):
     def __call__(
         self,
-        data: io.TextIOBase,
+        data_stream: io.TextIOBase,
         source: str,
         options: DocumentLoaderOptions,
     ) -> JsonLdRecord | list[JsonLdRecord]:
 
         try:
             yaml_documents_stream = yaml.load_all(  # noqa: S506
-                stream=data,
+                stream=data_stream,
                 Loader=YAMLLDLoader,
             )
 

--- a/yaml_ld/document_parsers/yaml_parser.py
+++ b/yaml_ld/document_parsers/yaml_parser.py
@@ -13,8 +13,10 @@ from yaml_ld.document_parsers.base import (
 from yaml_ld.errors import (
     DocumentIsScalar,
     InvalidEncoding,
+    InvalidScriptElement,
     LoadingDocumentFailed,
-    MappingKeyError, InvalidScriptElement, UndefinedAliasFound,
+    MappingKeyError,
+    UndefinedAliasFound,
 )
 from yaml_ld.loader import YAMLLDLoader
 from yaml_ld.models import JsonLdRecord

--- a/yaml_ld/document_parsers/yaml_parser.py
+++ b/yaml_ld/document_parsers/yaml_parser.py
@@ -22,7 +22,12 @@ from yaml_ld.models import JsonLdRecord
 
 
 class YAMLDocumentParser(BaseDocumentParser):
-    def __call__(self, data: io.TextIOBase, source: str, options: DocumentLoaderOptions) -> JsonLdRecord:
+    def __call__(
+        self,
+        data: io.TextIOBase,
+        source: str,
+        options: DocumentLoaderOptions,
+    ) -> JsonLdRecord | list[JsonLdRecord]:
 
         from yaml_ld.errors import MappingKeyError
 

--- a/yaml_ld/document_parsers/yaml_parser.py
+++ b/yaml_ld/document_parsers/yaml_parser.py
@@ -29,7 +29,7 @@ class YAMLDocumentParser(BaseDocumentParser):
         source: str,
         options: DocumentLoaderOptions,
     ) -> JsonLdRecord | list[JsonLdRecord]:
-
+        """Parse YAML document stream into LD."""
         try:
             yaml_documents_stream = yaml.load_all(  # noqa: S506
                 stream=data_stream,

--- a/yaml_ld/document_parsers/yaml_parser.py
+++ b/yaml_ld/document_parsers/yaml_parser.py
@@ -15,7 +15,7 @@ from yaml_ld.document_parsers.base import (
 from yaml_ld.errors import (
     DocumentIsScalar,
     InvalidEncoding,
-    LoadingDocumentFailed,
+    LoadingDocumentFailed, MappingKeyError,
 )
 from yaml_ld.loader import YAMLLDLoader
 from yaml_ld.models import JsonLdRecord
@@ -28,8 +28,6 @@ class YAMLDocumentParser(BaseDocumentParser):
         source: str,
         options: DocumentLoaderOptions,
     ) -> JsonLdRecord | list[JsonLdRecord]:
-
-        from yaml_ld.errors import MappingKeyError
 
         try:
             yaml_documents_stream = yaml.load_all(  # noqa: S506

--- a/yaml_ld/errors.py
+++ b/yaml_ld/errors.py
@@ -11,7 +11,7 @@ class YAMLLDError(DocumentedError):
 
 
 @dataclass
-class PyLDError(YAMLLDError):
+class PyLDError(YAMLLDError):   # type: ignore
     """{self.message}"""
 
     message: str
@@ -19,7 +19,7 @@ class PyLDError(YAMLLDError):
 
 
 @dataclass
-class DocumentIsScalar(YAMLLDError):
+class DocumentIsScalar(YAMLLDError):   # type: ignore
     """
     Document content MUST be sequence or mapping.
 
@@ -35,7 +35,7 @@ class DocumentIsScalar(YAMLLDError):
 
 
 @dataclass
-class LoadingDocumentFailed(YAMLLDError):
+class LoadingDocumentFailed(YAMLLDError):   # type: ignore
     """
     Document is not a valid YAML.
 
@@ -47,7 +47,7 @@ class LoadingDocumentFailed(YAMLLDError):
 
 
 @dataclass
-class NotFound(YAMLLDError):
+class NotFound(YAMLLDError):   # type: ignore
     """
     Document has not been found.
 
@@ -59,35 +59,35 @@ class NotFound(YAMLLDError):
 
 
 @dataclass
-class InvalidScriptElement(YAMLLDError):
+class InvalidScriptElement(YAMLLDError):   # type: ignore
     """HTML <script> element content is not valid YAML."""
 
     code: str = 'invalid script element'
 
 
 @dataclass
-class NoYAMLWithinHTML(YAMLLDError):
+class NoYAMLWithinHTML(YAMLLDError):   # type: ignore
     """No YAML-LD fragments found in an HTML document."""
 
     code: str = 'loading document failed'
 
 
 @dataclass
-class MappingKeyError(YAMLLDError):
+class MappingKeyError(YAMLLDError):   # type: ignore
     """A mapping key MUST be a string."""
 
     code: str = 'mapping-key-error'
 
 
 @dataclass
-class InvalidJSONLiteral(YAMLLDError):
+class InvalidJSONLiteral(YAMLLDError):   # type: ignore
     """A mapping key MUST be a string."""
 
     code: str = 'invalid JSON literal'
 
 
 @dataclass
-class InvalidEncoding(YAMLLDError):
+class InvalidEncoding(YAMLLDError):   # type: ignore
     """
     A YAML-LD document MUST be encoded in UTF-8.
 
@@ -98,21 +98,21 @@ class InvalidEncoding(YAMLLDError):
 
 
 @dataclass
-class CycleDetected(YAMLLDError):
+class CycleDetected(YAMLLDError):   # type: ignore
     """A YAML-LD document MUST NOT contain cycles."""
 
     code: str = 'loading document failed'
 
 
 @dataclass
-class UndefinedAliasFound(YAMLLDError):
+class UndefinedAliasFound(YAMLLDError):   # type: ignore
     """An undefined alias found."""
 
     code: str = 'loading document failed'
 
 
 @dataclass
-class LoadingRemoteContextFailed(YAMLLDError):
+class LoadingRemoteContextFailed(YAMLLDError):   # type: ignore
     """
     Failed to load the context.
 

--- a/yaml_ld/errors.py
+++ b/yaml_ld/errors.py
@@ -12,7 +12,7 @@ class YAMLLDError(DocumentedError):
 
 @dataclass
 class PyLDError(YAMLLDError):   # type: ignore
-    """{self.message}"""
+    """{self.message}"""   # noqa: D400
 
     message: str
     code: str

--- a/yaml_ld/expand.py
+++ b/yaml_ld/expand.py
@@ -22,7 +22,7 @@ from yaml_ld.models import (
 )
 
 
-class ExpandOptions(BaseOptions, ExtractAllScriptsOptions):
+class ExpandOptions(BaseOptions, ExtractAllScriptsOptions):   # type: ignore
     """Options for `jsonld.expand()`."""
 
     expand_context: JsonLdRecord | None = None

--- a/yaml_ld/flatten.py
+++ b/yaml_ld/flatten.py
@@ -10,7 +10,7 @@ from yaml_ld.models import (
 )
 
 
-class FlattenOptions(BaseOptions, ExtractAllScriptsOptions):
+class FlattenOptions(BaseOptions, ExtractAllScriptsOptions):   # type: ignore
     """Options to flatten a YAML-LD document."""
 
     expand_context: JsonLdRecord | None = None

--- a/yaml_ld/frame.py
+++ b/yaml_ld/frame.py
@@ -1,6 +1,4 @@
-from enum import StrEnum
-
-from pydantic import field_serializer, validate_call
+from pydantic import validate_call
 from pyld import jsonld
 
 from yaml_ld.expand import except_json_ld_errors
@@ -10,13 +8,6 @@ from yaml_ld.models import (
     JsonLdInput,
     JsonLdRecord,
 )
-
-
-class Embed(StrEnum):
-    LAST = '@last'
-    ALWAYS = '@always'
-    NEVER = '@never'
-    LINK = '@link'
 
 
 class FrameOptions(BaseOptions, ExtractAllScriptsOptions):   # type: ignore

--- a/yaml_ld/frame.py
+++ b/yaml_ld/frame.py
@@ -19,7 +19,7 @@ class Embed(StrEnum):
     LINK = '@link'
 
 
-class FrameOptions(BaseOptions, ExtractAllScriptsOptions):
+class FrameOptions(BaseOptions, ExtractAllScriptsOptions):   # type: ignore
     """Options for YAML-LD framing."""
 
     expand_context: JsonLdRecord | None = None

--- a/yaml_ld/from_rdf.py
+++ b/yaml_ld/from_rdf.py
@@ -3,10 +3,9 @@ from pyld import jsonld
 
 from yaml_ld.expand import except_json_ld_errors
 from yaml_ld.models import BaseOptions, JsonLdRecord
-from yaml_ld.rdf import Dataset
 
 
-class FromRDFOptions(BaseOptions):
+class FromRDFOptions(BaseOptions):   # type: ignore
     """Options for converting RDF to YAML-LD."""
 
     format: str = 'application/n-quads'

--- a/yaml_ld/models.py
+++ b/yaml_ld/models.py
@@ -42,7 +42,7 @@ class ProcessingMode(str, Enum):  # noqa: WPS600
     JSON_LD_1_1 = 'json-ld-1.1'  # noqa: WPS114, WPS115
 
 
-class ExtractAllScriptsOptions(BaseModel):
+class ExtractAllScriptsOptions(BaseModel):    # type: ignore
     """Options flag to extract all scripts or not."""
 
     extract_all_scripts: bool = False
@@ -57,7 +57,7 @@ def _default_document_loader():
     return DEFAULT_DOCUMENT_LOADER
 
 
-class BaseOptions(BaseModel):
+class BaseOptions(BaseModel):   # type: ignore
     """Base options shared by all YAML-LD API methods."""
 
     base: str | Path | None = None

--- a/yaml_ld/to_rdf.py
+++ b/yaml_ld/to_rdf.py
@@ -6,7 +6,7 @@ from yaml_ld.models import BaseOptions, ExtractAllScriptsOptions, JsonLdInput
 from yaml_ld.rdf import Dataset
 
 
-class ToRDFOptions(BaseOptions, ExtractAllScriptsOptions):
+class ToRDFOptions(BaseOptions, ExtractAllScriptsOptions):   # type: ignore
     """Options for converting YAML-LD to RDF."""
 
     format: str = 'application/n-quads'


### PR DESCRIPTION
- At 11 `mypy` errors now
- `mypy` error count down to 0
- Auto format
- Relax dependencies version constraints
- Fix a few linter errors
- `data` → `data_straem`
- Auto format
- A few more linter errors fixed
- Refactor `YAMLDocumentParser.__call__`
- `yaml_parser.py` linters 🟢
- Fix a few linter errors
- A few more linter errors now 🟢
- Linters are now 🟢 yayyyy!!!
- Run lint @ CI
