### PR TITLE
278 knowledge representation language from fip ontology wont load

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yaml-ld"
-version = "1.1.3"
+version = "1.1.4"
 description = "YAML-LD for Python"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"

--- a/yaml_ld/document_loaders/content_types.py
+++ b/yaml_ld/document_loaders/content_types.py
@@ -1,12 +1,15 @@
 import functools
 from dataclasses import dataclass
+from pathlib import Path
 
 from documented import DocumentedError
+from yarl import URL
 
 from yaml_ld.document_parsers.base import BaseDocumentParser
 from yaml_ld.document_parsers.rdf_xml_parser import RDFXMLParser
 from yaml_ld.document_parsers.turtle_parser import TurtleParser
 from yaml_ld.document_parsers.yaml_parser import YAMLDocumentParser
+from yaml_ld.models import URI
 
 # FIXME
 #   - I've copied it over from pyld;
@@ -19,6 +22,31 @@ DEFAULT_ACCEPT_HEADER = ', '.join([
     'text/html;q=0.8',
     'application/xhtml+xml;q=0.8',
 ])
+
+
+def construct_accept_header(url: URI) -> str:
+    """Construct headers for a URL."""
+    match url:
+        case URL() as url:
+            url = str(url)
+
+        case Path():
+            return DEFAULT_ACCEPT_HEADER
+
+    # FIXME: Use JsonLdInput as argument instead of URI type
+
+    # FIXME:
+    #    * Make this configurable and extendable
+    #    * Maybe move this to pyld, test URL:
+    #    ```
+    #    https://w3id.org/fair/fip/terms/Knowledge-representation-language
+    #    ```
+    if url.startswith('https://w3id.org/fair/fip/terms/'):
+        # Content negotiation will not work correctly because w3id does not
+        # support content type weights. It will return the text/html version.
+        return 'application/ld+json'
+
+    return DEFAULT_ACCEPT_HEADER
 
 
 def by_extension(extension: str) -> str | None:

--- a/yaml_ld/load_document.py
+++ b/yaml_ld/load_document.py
@@ -1,7 +1,7 @@
 from pydantic import validate_call
 from pyld import jsonld
 
-from yaml_ld.document_loaders.content_types import DEFAULT_ACCEPT_HEADER
+from yaml_ld.document_loaders.content_types import construct_accept_header
 from yaml_ld.document_loaders.default import DEFAULT_DOCUMENT_LOADER
 from yaml_ld.models import DEFAULT_VALIDATE_CALL_CONFIG, RemoteDocument
 from yaml_ld.options import BaseOptions
@@ -23,7 +23,7 @@ def load_document(
     The document can be retrieved from local filesystem or from the Web.
     """
     headers = {
-        'Accept': DEFAULT_ACCEPT_HEADER,
+        'Accept': construct_accept_header(url),
     }
 
     if requestProfile:

--- a/yaml_ld/to_rdf.py
+++ b/yaml_ld/to_rdf.py
@@ -1,11 +1,15 @@
 from pydantic import validate_call
 from pyld import jsonld
 
-from yaml_ld.document_loaders.content_types import DEFAULT_ACCEPT_HEADER
+from yaml_ld.document_loaders.content_types import (
+    DEFAULT_ACCEPT_HEADER,
+    construct_accept_header,
+)
 from yaml_ld.document_loaders.default import DEFAULT_DOCUMENT_LOADER
 from yaml_ld.expand import except_json_ld_errors
 from yaml_ld.models import (
     DEFAULT_VALIDATE_CALL_CONFIG,
+    URI,
     JsonLdInput,
     ensure_string_or_document,
 )
@@ -38,7 +42,13 @@ def to_rdf(
     """Convert a [＊-LD](/blog/any-ld/) document to RDF."""
     dict_options = options.model_dump(by_alias=True, exclude_none=True)
     dict_options.setdefault('documentLoader', DEFAULT_DOCUMENT_LOADER)
-    dict_options.setdefault('headers', {'Accept': DEFAULT_ACCEPT_HEADER})
+
+    accept_header = DEFAULT_ACCEPT_HEADER
+    if isinstance(document, URI):
+        accept_header = construct_accept_header(document)
+
+    dict_options.setdefault('headers', {'Accept': accept_header})
+
     dict_options['extractAllScripts'] = True
 
     with except_json_ld_errors():


### PR DESCRIPTION
- **#278 ➕ `construct_accept_header()`**
- **#278 `load_document()` now composes headers dynamically**
- **#278 `to_rdf()` now composes headers dynamically**
- **#278 Bump version**
