### PR TITLE
283 httpspurlorgnetrdflicensew3c10ttl crashes python yaml ld

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yaml-ld"
-version = "1.1.5"
+version = "1.1.6"
 description = "YAML-LD for Python"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"

--- a/yaml_ld/document_loaders/content_types.py
+++ b/yaml_ld/document_loaders/content_types.py
@@ -63,6 +63,7 @@ def by_extension(extension: str) -> str | None:
         '.yaml': 'application/yaml',
         '.yamlld': 'application/ld+yaml',
         '.html': 'text/html',
+        '.ttl': 'text/turtle',
     }.get(extension)
 
 


### PR DESCRIPTION
- **#283 `.ttl` → Turtle**
- **#283 Choose between content types more intelligently**
- **#283 Version bump**
