### PR TITLE
287 unit tests crash due to an iolanta type error

### DIFF
--- a/ldtest/data/context.json
+++ b/ldtest/data/context.json
@@ -1,5 +1,0 @@
-{
-  "@context": {
-    "tests": "https://w3c.github.io/json-ld-api/tests/vocab#"
-  }
-}

--- a/ldtest/data/is-facet-of.yaml
+++ b/ldtest/data/is-facet-of.yaml
@@ -1,3 +1,0 @@
-$id: iolanta:isFacetOf
-owl:inverseOf:
-  $id: iolanta:facet

--- a/ldtest/data/subclasses.yaml
+++ b/ldtest/data/subclasses.yaml
@@ -1,10 +1,17 @@
+"@context":
+  "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
+  tests: https://w3c.github.io/json-ld-api/tests/vocab#
+  iolanta: https://iolanta.tech/
+
 $id: python://ldtest.JSONLDTests
-iolanta:supports:
-  $id: pytest
-iolanta:isFacetOf:
-  - $id: tests:ExpandTest
-  - $id: tests:ToRDFTest
-  - $id: tests:FromRDFTest
-  - $id: tests:CompactTest
-  - $id: tests:FlattenTest
-  - $id: tests:FrameTest
+iolanta:outputs:
+  $id: https://pytest.org
+
+$reverse:
+  iolanta:facet:
+    - $id: tests:ExpandTest
+    - $id: tests:ToRDFTest
+    - $id: tests:FromRDFTest
+    - $id: tests:CompactTest
+    - $id: tests:FlattenTest
+    - $id: tests:FrameTest

--- a/ldtest/data/test.yaml
+++ b/ldtest/data/test.yaml
@@ -1,3 +1,7 @@
+"@context":
+  "@import": https://json-ld.org/contexts/dollar-convenience.jsonld
+  tests: https://w3c.github.io/json-ld-api/tests/vocab#
+
 $id: tests:Test
 
 rdfs:subClassOf:
@@ -6,5 +10,5 @@ rdfs:subClassOf:
 
 iolanta:hasInstanceFacet:
   $id: python://ldtest.JSONLDTest
-  iolanta:supports:
-    $id: pytest
+  iolanta:outputs:
+    $id: https://pytest.org

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yaml-ld"
-version = "1.1.7"
+version = "1.1.8"
 description = "YAML-LD for Python"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"

--- a/tests/common.py
+++ b/tests/common.py
@@ -14,25 +14,26 @@ tests_root = Path(__file__).parent
 project_root = tests_root.parent
 specifications_root = project_root / 'specifications'
 
+PYTEST = URIRef('https://pytest.org')
 
-@functools.lru_cache
+
 def iolanta() -> Iolanta:
     # Load the JSON-LD tests from the test suite
     # Return a list of test cases
     graph = ConjunctiveGraph()
     for manifest_path in specifications_root.glob('*/tests/*manifest.jsonld'):
         # FIXME: Use `iolanta.add()`.
-        #   At this point, we can't do that: `iolanta` does not resolve the
-        #   `context.jsonld` file which this document is referring to.
         graph.parse(manifest_path)
 
-    return Iolanta(graph=graph, force_plugins=[LDTest])
+    return Iolanta(
+        graph=graph,
+        project_root=project_root / 'ldtest' / 'data',
+        force_plugins=[LDTest],
+    )
 
 
 def load_tests(test_class: URIRef) -> Iterable[TestCase]:
-    return funcy.first(
-        iolanta().render(
-            node=test_class,
-            environments=[LOCAL.pytest],
-        ),
+    return iolanta().render(
+        node=test_class,
+        as_datatype=PYTEST,
     )

--- a/yaml_ld/document_loaders/http.py
+++ b/yaml_ld/document_loaders/http.py
@@ -228,6 +228,8 @@ class HTTPDocumentLoader(DocumentLoader):
 
             raise
 
+        string_source = response.url
+
         mime_type_from_headers = None
         if raw_content_type := response.headers.get('Content-Type'):
             mime_type_from_headers = parse_content_type(


### PR DESCRIPTION
- **#287 Rewrite the `ldtest` data**
- **#287 Bump version**
- **#287 Iolanta interface has changed, should adapt**
- **#287 After a redirect, use the new URL**
