### PR TITLE
Handle read-only default cache directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yaml-ld"
-version = "1.1.18"
+version = "1.1.19"
 description = "YAML-LD for Python"
 authors = ["Anatoly Scherbakov <altaisoft@gmail.com>"]
 license = "MIT"

--- a/tests/test_default_document_loader.py
+++ b/tests/test_default_document_loader.py
@@ -1,0 +1,120 @@
+from requests import Response, Session
+from yarl import URL
+
+from yaml_ld.document_loaders import default
+
+
+class FakeSession(Session):
+    def __init__(self, response: Response):
+        super().__init__()
+        self.response = response
+
+    def get(self, *args, **kwargs):  # noqa: WPS110
+        return self.response
+
+
+class BrokenCachedSession:
+    def __init__(self, *args, **kwargs):
+        raise OSError("read-only cache")
+
+
+def _json_ld_response(url: str) -> Response:
+    response = Response()
+    response.status_code = 200
+    response.url = url
+    response.headers["Content-Type"] = "application/ld+json"
+    response._content = b'{"@id": "https://example.test/alice"}'
+    return response
+
+
+def test_cache_directory_uses_writable_user_cache(monkeypatch, tmp_path):
+    user_cache_directory = tmp_path / "user-cache"
+    temporary_cache_directory = tmp_path / "temporary-cache"
+
+    monkeypatch.setattr(
+        default,
+        "_user_cache_directory",
+        lambda: user_cache_directory,
+    )
+    monkeypatch.setattr(
+        default,
+        "_temporary_cache_directory",
+        lambda: temporary_cache_directory,
+    )
+
+    assert default._cache_directory() == user_cache_directory
+    assert user_cache_directory.is_dir()
+    assert not temporary_cache_directory.exists()
+
+
+def test_cache_directory_falls_back(
+    monkeypatch,
+    tmp_path,
+):
+    user_cache_directory = tmp_path / "user-cache"
+    temporary_cache_directory = tmp_path / "temporary-cache"
+
+    monkeypatch.setattr(
+        default,
+        "_user_cache_directory",
+        lambda: user_cache_directory,
+    )
+    monkeypatch.setattr(
+        default,
+        "_temporary_cache_directory",
+        lambda: temporary_cache_directory,
+    )
+    monkeypatch.setattr(
+        default,
+        "_is_writable_directory",
+        lambda directory: directory != user_cache_directory,
+    )
+
+    assert default._cache_directory() == temporary_cache_directory
+
+
+def test_cached_session_falls_back(monkeypatch, tmp_path):
+    monkeypatch.setattr(default, "CachedSession", BrokenCachedSession)
+
+    assert isinstance(default._cached_session(tmp_path), Session)
+
+
+def test_http_loader_returns_with_fallback(
+    monkeypatch,
+    tmp_path,
+):
+    url = "https://example.test/person"
+    user_cache_directory = tmp_path / "user-cache"
+    temporary_cache_directory = tmp_path / "temporary-cache"
+    response = _json_ld_response(url=url)
+
+    monkeypatch.setattr(
+        default,
+        "_user_cache_directory",
+        lambda: user_cache_directory,
+    )
+    monkeypatch.setattr(
+        default,
+        "_temporary_cache_directory",
+        lambda: temporary_cache_directory,
+    )
+    monkeypatch.setattr(
+        default,
+        "_is_writable_directory",
+        lambda directory: directory != user_cache_directory,
+    )
+
+    assert default._cache_directory() == temporary_cache_directory
+
+    document = default.HTTPDocumentLoader(
+        session=FakeSession(response=response),
+    )(
+        source=URL(url),
+        options={
+            "base": url,
+            "extractAllScripts": False,
+            "headers": {},
+        },
+    )
+
+    assert document["document"] == {"@id": "https://example.test/alice"}

--- a/yaml_ld/document_loaders/default.py
+++ b/yaml_ld/document_loaders/default.py
@@ -1,4 +1,10 @@
+import logging
 import platformdirs
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from requests import Session
 from requests_cache import CachedSession
 
 from yaml_ld.document_loaders.choice_by_scheme import (
@@ -7,14 +13,68 @@ from yaml_ld.document_loaders.choice_by_scheme import (
 from yaml_ld.document_loaders.http import HTTPDocumentLoader
 from yaml_ld.document_loaders.local_file import LocalFileDocumentLoader
 
-CACHE_DIRECTORY = platformdirs.user_cache_dir(
-    appname='python-yaml-ld',
-    ensure_exists=True,
-)
+APP_NAME = "python-yaml-ld"
+_WRITE_TEST_FILE = ".write-test"
+logger = logging.getLogger(__name__)
 
-CACHED_SESSION = CachedSession(
-    backend='filesystem',
-    cache_name=CACHE_DIRECTORY,
+
+def _user_cache_directory() -> Path:
+    return Path(
+        platformdirs.user_cache_dir(
+            appname=APP_NAME,
+            ensure_exists=False,
+        )
+    )
+
+
+def _temporary_cache_directory() -> Path:
+    return Path(tempfile.gettempdir()) / APP_NAME
+
+
+def _write_test_file(directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    write_test_path = directory / _WRITE_TEST_FILE
+    write_test_path.write_text("", encoding="utf-8")
+    write_test_path.unlink(missing_ok=True)
+
+
+def _is_writable_directory(directory: Path) -> bool:
+    try:
+        _write_test_file(directory=directory)
+    except OSError:
+        return False
+
+    return True
+
+
+def _cache_directory() -> Path:
+    user_cache_directory = _user_cache_directory()
+    if _is_writable_directory(user_cache_directory):
+        return user_cache_directory
+
+    return _temporary_cache_directory()
+
+
+def _cached_session(cache_directory: Path) -> Session:
+    try:
+        return CachedSession(
+            backend="filesystem",
+            cache_name=cache_directory,
+        )
+    except (OSError, KeyError, sqlite3.Error) as error:
+        logger.warning(
+            "Cannot use requests cache directory %s: %s",
+            cache_directory,
+            error,
+        )
+
+        return Session()
+
+
+CACHE_DIRECTORY = _cache_directory()
+
+CACHED_SESSION = _cached_session(
+    cache_directory=CACHE_DIRECTORY,
 )
 
 http_loader = HTTPDocumentLoader(


### PR DESCRIPTION
## Summary

- Probe the platform user cache directory before constructing the default `requests-cache` session.
- Fall back to a deterministic temp cache directory when the platform cache is not writable.
- Keep document loading available with a plain `requests.Session` if cached session construction fails.
- Add regression tests for writable cache, fallback cache, cached-session fallback, and HTTP loading through the fallback path.

## Validation

- `poetry install`
- `j fmt`
- `poetry run pytest tests/test_default_document_loader.py`
- `j lint`